### PR TITLE
Ensure that Boolector is using the correct headers for the symbol S_IRWXU

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -1,0 +1,1 @@
+Andrew V. Jones, Vector Informatik

--- a/src/btormbt.c
+++ b/src/btormbt.c
@@ -34,6 +34,7 @@
 #include <sys/times.h>
 #include <sys/types.h>
 #include <sys/wait.h>
+#include <sys/stat.h>
 #include <unistd.h>
 
 /*------------------------------------------------------------------------*/


### PR DESCRIPTION
Boolector's MBT module attempts to use the symbol "S_IRWXU". However, on older machines (e.g., Red Hat Enterprise Linux 5), this symbol is not (transitively) visible via the headers that are currently included.

This PR ensures that the correct header (<sys/stat.h>) is #included.

Minor: this PR also introduces a CONTRIBUTORS file.