### PR TITLE
Correcting include files to allow for particular symbols (e.g., WEXITSTATUS) to be visible

### DIFF
--- a/src/tests/testparseerror.c
+++ b/src/tests/testparseerror.c
@@ -24,6 +24,7 @@
 #include <string.h>
 #include <sys/stat.h>
 #include <sys/types.h>
+#include <sys/wait.h>
 #include <unistd.h>
 
 char *g_name     = NULL;


### PR DESCRIPTION
The file `src/tests/testparseerror.c` uses the symbol `WEXITSTATUS` without the correct include file (`#include <sys/wait.h>`).

This PR rectifies this issue.