### PR TITLE
Fixing off-by-one issue in the encoding of `distinct` for SMT2

### DIFF
--- a/src/parser/btorsmt2.c
+++ b/src/parser/btorsmt2.c
@@ -2122,7 +2122,7 @@ parse_term_aux_smt2 (BtorSMT2Parser *parser,
         exp = boolector_ne (parser->btor, p[1].exp, p[2].exp);
         for (i = 1; i < nargs; i++)
         {
-          for (j = i + 2; j <= nargs; j++)
+          for (j = i + 1; j <= nargs; j++)
           {
             tmp = boolector_ne (parser->btor, p[i].exp, p[j].exp);
             old = exp;


### PR DESCRIPTION
Fixes #6 .

@aniemetz what's the best way to add a test for this bug?