### PR TITLE
cmake: fixed race condition on cython dependencies

### DIFF
--- a/src/api/python/CMakeLists.txt
+++ b/src/api/python/CMakeLists.txt
@@ -26,6 +26,7 @@ add_custom_target(
 add_cython_target(pyboolector)  # implicitely uses pyboolector.pyx
 
 add_library(pyboolector MODULE ${pyboolector} boolector_py.c)
+add_dependencies(pyboolector pyboolector_options)
 
 target_link_libraries(pyboolector boolector ${LIBRARIES} ${PYTHON_LIBRARIES})
 python_extension_module(pyboolector)


### PR DESCRIPTION
When running make with multiple threads (make -j2) the file
pyboolector_options.pxd would be typically generated before trying to
compile the cython module. However, the dependency was not explicit,
causing race conditions and errors in single-thread builds.

The dependency is now explicit.