### PR TITLE
Add documentation and patches for a Windows build

### DIFF
--- a/COMPILING_WIN32.md
+++ b/COMPILING_WIN32.md
@@ -1,0 +1,195 @@
+# Boolector installation steps on Windows
+
+### Important preamble
+
+These steps document what is necessary to build a 32-bit version of `pyboolector.pyd` on 64-bit Windows. These steps _probably_ work for a 64-bit version, but have not been tested. They also do not guarantee the correctness of other parts of Boolector (e.g., the main `boolector.exe`).
+
+To ensure the portability of `pyboolector.pyd`, every effort is made in this guide to avoid building Boolector with Cygwin (e.g., we wish to avoid a dependency on `cygwin1.dll`, which could affect the portability of `pyboolector.pyd`). Given this, the guide is written to use the MinGW-W64 "cross-compiler".
+
+These notes are purposefully very detailed to allow for someone to go from a completely fresh Windows 10 installation to a working version of Boolector.
+
+Finally, some of Boolector's dependencies have been _heavily_ modified to allow them to build on Windows. This means that functionality such as timeouts might be completely inoperable on Windows.
+
+
+## Dependencies
+
+### MinGW
+
+Install MinGW-W64 from here:
+
+* <https://sourceforge.net/projects/mingw-w64/files/mingw-w64/mingw-w64-release/>
+
+You should select the "MinGW-W64 Online Installer" (`MinGW-W64-install.exe`).
+
+The following options are recommended and have been tested when writing this guide:
+
+* Version: 4.9.4
+* Architecture: i686
+* Threads: win32
+* Exception: dwarf (default)
+* Build revision: 0 (default)
+
+When selecting the threading model, only the Win32 model has been validated -- the POSIX model has not been tested at all. On Windows, Boolector's make system has been modified to statically link, expecting the Win32 model.
+
+
+### MSYS
+
+Install MSYS from here:
+
+* <https://www.msys2.org>
+
+It is important to select the 32-bit installation option (`msys2-i686-<DATE>.exe`). There are no further choices to be made when installing MSYS.
+
+Once MSYS is installed, start an MSYS shell, and run `pacman -Syuu`. Once this is complete, it will ask you to close the shell. Close MSYS, re-open it and re-run `pacman -Syuu` again. Once it is complete the second time, close and re-open MSYS. This process needs to be performed twice to allow for MSYS to first update itself, and then update its packages.
+
+Now install the following:
+
+* `pacman -S --needed make git vim wget patch tar`
+
+
+### Python 2.7
+
+Install the most recent 32-bit Python 2.7 from here:
+
+* <https://www.python.org/downloads/windows/>
+
+You should download the _x86 MSI_. No specific choices need to be made when installing Python.
+
+Update your `%PATH%` variable to include both the path to `python.exe ` and to the `Scripts` sub-directory of the Python installation. These paths will look something like:
+
+* `C:\Python27`
+* `C:\Python27\Scripts`
+
+Once your `%PATH%` is set correctly, start `cmd` and run the following:
+
+* `python -m pip install --upgrade pip`
+* `python -m pip install --upgrade cython`
+
+You now need to edit the file `cygwinccompiler.py` in your Python installation directory to avoid the use of the `-mno-cygwin` flag. The path to this file is commonly found here: `C:\Python27\Lib\distutils\cygwinccompiler.py`. You should change the line `no_cygwin = ' -mno-cygwin'` to read `no_cygwin = ''` (so empty quotes). On Python 2.7.15, the line number is 323.
+
+
+### CMake
+
+The version of CMake that comes with MSYS does not correctly support MSYS Makefiles (strangely). You should download the most recent version of CMake from here:
+
+* <https://cmake.org/download/>
+
+Downloading "Windows win32-x86 ZIP" (`cmake-<VERSION>-win32-x86.zip`) is sufficient. You do not need the installer.
+
+When this is downloaded, extract the zip, but _remember the path you extracted it to_! You will need it later to the set the variable `CMAKE_DIR`.
+
+
+## Building Boolector
+
+### Configuring Boolector's build environment
+
+Now that you have installed all of the necessary dependencies for Boolector, we need to configure our build environment. Start an MSYS shell, enter the directory you wish to build Boolector in, and create a file called `vars.sh`. The file should have the following content:
+
+```bash
+#!/bin/bash
+
+export PYTHON_DIR=$(cygpath -u "C:\Python27")
+export CMAKE_DIR=$(cygpath -u "C:\cmake-3.12.1-win32-x86")
+export MINGW_DIR=$(cygpath -u "C:\Program Files (x86)\mingw-w64\i686-4.9.4-win32-dwarf-rt_v5-rev0\mingw32")
+
+export PATH=${PYTHON_DIR}:${PATH}
+export PATH=${PYTHON_DIR}/Scripts:${PATH}
+export PATH=${CMAKE_DIR}/bin:${PATH}
+export PATH=${MINGW_DIR}/bin:${PATH}
+
+# export DEBUG_FLAG="-g"
+export DEBUG_FLAG=""
+export COMPARCH=32   # for a 32-bit build!
+
+export EXTRA_FLAGS="-static-libstdc++ -static-libgcc"
+export COMPFLAGS="${EXTRA_FLAGS} -I${PYTHON_DIR}/include -m${COMPARCH}"
+
+if [ -z "$DEBUG_FLAG" ]; then
+    COMPFLAGS="-O3 -DNDEBUG ${COMPFLAGS}"
+fi
+
+export CFLAGS="${COMPFLAGS} -std=gnu11"
+export CXXFLAGS="${COMPFLAGS} -std=gnu++11"
+export PYTHON_INCLUDE="${COMPFLAGS}"
+export LDFLAGS="${EXTRA_FLAGS} -L${PYTHON_DIR}/lib"
+
+export CC="gcc"
+export CXX="g++"
+
+# EOF
+```
+
+Once you have created this file, you should run `source vars.sh`. You should now check the following:
+
+* `which gcc`
+* `which python`
+* `which cmake`
+* `which cython`
+
+If any of these do not appear to look right, or return incorrect values, you need to check your contents of `vars.sh` -- pay special attention to `CMAKE_DIR` and `MINGW_DIR`!
+
+
+### Obtaining Boolector
+
+Now that you have configured your environment, you should obtain a copy of Boolector:
+
+* `git clone https://github.com/Boolector/boolector`
+
+
+### Building Boolector
+
+The following steps will allow you to build Boolector from the above clone:
+
+```bash
+#!/bin/bash
+
+cd boolector
+
+#
+# Download, patch and build Boolector's dependencies
+#
+./contrib/setup-picosat.sh
+./contrib/setup-lingeling.sh
+./contrib/setup-cadical.sh
+./contrib/setup-btor2tools.sh
+
+#
+# Modify pyboolector.pyx to be "more Windows compatible"
+#
+./contrib/fix_cython_windows.sh
+
+#
+# Build Boolector
+#
+mkdir build
+cd build
+cmake .. -DPYTHON=ON -DIS_WINDOWS_BUILD=1 -G "MSYS Makefiles"
+make -j12
+cd ..
+
+# EOF
+```
+
+_Notes:_
+
+* On Windows, the above `setup` scripts automatically patch the version of Boolector's dependencies to enable them to compile with Windows -- as per the start of this guide, these changes may dramatically change Boolector's behaviour.
+* The use of `-G "MSYS Makefiles"` is _highly_ essential to allow you to build Boolector on Windows.
+
+
+### Testing Boolector
+
+Now that you have built `pyboolector.pyd`, you can test it:
+
+```bash
+#!/bin/bash
+
+# this script presumes it is run from the root of the Boolector clone
+
+export PYTHONPATH=$(cygpath -d $(readlink -f build/lib))
+python examples/api/python/api_usage_examples.py
+
+# EOF
+```
+
+If you get uncaught exceptions on on `splice`, then you probably did not run `./contrib/fix_cython_windows.sh` before building.
+

--- a/contrib/fix_cython_windows.sh
+++ b/contrib/fix_cython_windows.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+#
+# Cython on Windows has some differences when compared to Linux, which ends up
+# to certain expectations inside of pyboolector.pyx not being met.
+#
+# This file modifies pyboolector.pyx to try and avoid these -- it is not a
+# patch-set because we want to avoid it being tied to a specific version of
+# Boolector.
+#
+
+set -e
+set -u
+
+PYX=src/api/python/pyboolector.pyx
+
+#
+# Avoid oddities with older version of Python and math.log on a long
+#
+sed -i 's/math.log(a.width/math.log(int(a.width)/g' ${PYX}
+
+#
+# Avoid self.width being a long and failing a check
+#
+sed -i 's/upper = self.width/upper = int(self.width)/g' ${PYX}
+
+# EOF

--- a/contrib/setup-btor2tools.sh
+++ b/contrib/setup-btor2tools.sh
@@ -9,8 +9,21 @@ mkdir -p ${SETUP_DIR}
 
 BTOR2TOOLS_DIR=${SETUP_DIR}/btor2tools
 
-# Download and build CaDiCaL
+# Download and build btor2tools
 git clone --depth 1 https://github.com/Boolector/btor2tools.git ${BTOR2TOOLS_DIR}
 cd ${BTOR2TOOLS_DIR}
+case "$(uname -s)" in
+   CYGWIN*|MINGW32*|MSYS*)
+     revision=8c150b3
+     echo ""
+     echo " *** WARNING: Building btor2tools on Windows relies on a specific"
+     echo " ***          revision (${revision})."
+     echo " ***          This version of Boolector may be built against an"
+     echo " ***          older version of btor2tools."
+     echo ""
+     git reset --hard "${revision}"
+     patch -p1 < ../../contrib/windows_patches/btor2tools_"${revision}".patch
+     ;;
+esac
 ./configure.sh -fPIC
 make -j2

--- a/contrib/setup-cadical.sh
+++ b/contrib/setup-cadical.sh
@@ -12,5 +12,19 @@ CADICAL_DIR=${SETUP_DIR}/cadical
 # Download and build CaDiCaL
 git clone --depth 1 https://github.com/arminbiere/cadical.git ${CADICAL_DIR}
 cd ${CADICAL_DIR}
-CXXFLAGS="-fPIC" ./configure
+case "$(uname -s)" in
+   CYGWIN*|MINGW32*|MSYS*)
+     revision=58331fd
+     echo ""
+     echo " *** WARNING: Building CaDiCaL on Windows relies on a specific"
+     echo " ***          revision (${revision})."
+     echo " ***          This version of Boolector may be built against an"
+     echo " ***          older version of CaDiCaL."
+     echo ""
+     git reset --hard "${revision}"
+     patch -p1 < ../../contrib/windows_patches/cadical_"${revision}".patch
+     EXTRA_FLAGS="-q"
+     ;;
+esac
+CXXFLAGS="-fPIC" ./configure ${EXTRA_FLAGS}
 make -j2

--- a/contrib/setup-lingeling.sh
+++ b/contrib/setup-lingeling.sh
@@ -12,5 +12,18 @@ LINGELING_DIR=${SETUP_DIR}/lingeling
 # Download and build Lingeling
 git clone --depth 1 https://github.com/arminbiere/lingeling.git ${LINGELING_DIR}
 cd ${LINGELING_DIR}
+case "$(uname -s)" in
+   CYGWIN*|MINGW32*|MSYS*)
+     revision=03b4860
+     echo ""
+     echo " *** WARNING: Building Lingeling on Windows relies on a specific"
+     echo " ***          revision (${revision})."
+     echo " ***          This version of Boolector may be built against an"
+     echo " ***          older version of Lingeling."
+     echo ""
+     git reset --hard "${revision}"
+     patch -p1 < ../../contrib/windows_patches/lingeling_"${revision}".patch
+     ;;
+esac
 ./configure.sh -fPIC
 make -j2

--- a/contrib/setup-picosat.sh
+++ b/contrib/setup-picosat.sh
@@ -16,5 +16,11 @@ wget http://fmv.jku.at/picosat/picosat-965.tar.gz
 tar xzf picosat-965.tar.gz
 mv picosat-965/* .
 rmdir picosat-965
-./configure.sh --shared
+case "$(uname -s)" in
+   CYGWIN*|MINGW32*|MSYS*)
+     patch -p1 < ../../contrib/windows_patches/picosat-965.patch
+     EXTRA_FLAGS="--optimize --no-stats --no-trace"
+     ;;
+esac
+./configure.sh --shared ${EXTRA_FLAGS}
 make -j2

--- a/contrib/windows_patches/btor2tools_8c150b3.patch
+++ b/contrib/windows_patches/btor2tools_8c150b3.patch
@@ -1,0 +1,16 @@
+diff --git a/configure.sh b/configure.sh
+--- a/configure.sh
++++ b/configure.sh
+@@ -70,10 +70,10 @@ done
+ 
+ [ X"$CC" = X ] && CC=gcc
+ 
+-if [ X"$CFLAGS" = X ]
++if [ TRUE ]
+ then
+   [ $debug = unknown ] && debug=no
+-  CFLAGS="-W -Wall -Wextra -Wredundant-decls -std=gnu99"
++  CFLAGS="$CFLAGS -W -Wall -Wextra -Wredundant-decls -std=gnu99"
+   [ $static = yes ] && CFLAGS="$CFLAGS -static"
+   [ $shared = yes ] && CFLAGS="$CFLAGS -fPIC"
+   [ $flags = none ] || CFLAGS="$CFLAGS $flags"

--- a/contrib/windows_patches/cadical_58331fd.patch
+++ b/contrib/windows_patches/cadical_58331fd.patch
@@ -1,0 +1,103 @@
+diff --git a/src/resources.cpp b/src/resources.cpp
+--- a/src/resources.cpp
++++ b/src/resources.cpp
+@@ -9,7 +9,9 @@
+ 
+ extern "C" {
+ #include <sys/time.h>
++#ifdef NWINDOWS
+ #include <sys/resource.h>
++#endif
+ #include <sys/types.h>
+ #include <unistd.h>
+ #include <string.h>
+@@ -24,12 +26,16 @@ namespace CaDiCaL {
+ // of Unix not all fields are meaningful (or even existing).
+ 
+ double process_time () {
++#ifdef NWINDOWS
+   struct rusage u;
+   double res;
+   if (getrusage (RUSAGE_SELF, &u)) return 0;
+   res = u.ru_utime.tv_sec + 1e-6 * u.ru_utime.tv_usec;  // user time
+   res += u.ru_stime.tv_sec + 1e-6 * u.ru_stime.tv_usec; // + system time
+   return res;
++#else
++  return 0;
++#endif
+ }
+ 
+ // This seems to work on Linux (man page says since Linux 2.6.32).
+diff --git a/src/signal.cpp b/src/signal.cpp
+index a38e577..3985d93 100644
+--- a/src/signal.cpp
++++ b/src/signal.cpp
+@@ -6,7 +6,13 @@
+ #include <csignal>
+ #include <cassert>
+ 
+-int CaDiCaL::Solver::contract_violation_signal = SIGUSR1;
++#ifdef NWINDOWS
++#define VSIG SIGUR1
++#else
++#define VSIG SIGINT
++#endif
++
++int CaDiCaL::Solver::contract_violation_signal = VSIG;
+ 
+ /*------------------------------------------------------------------------*/
+ 
+@@ -29,8 +35,12 @@ SIGNAL(SIGINT) \
+ SIGNAL(SIGSEGV) \
+ SIGNAL(SIGABRT) \
+ SIGNAL(SIGTERM) \
++
++#ifdef NWINDOWS
+ SIGNAL(SIGBUS) \
+ 
++#endif
++
+ #define SIGNAL(SIG) \
+ static void (*SIG ## _handler)(int);
+ SIGNALS
+@@ -38,6 +48,7 @@ SIGNALS
+ static void (*SIGALRM_handler)(int);
+ 
+ void Signal::reset () {
++#ifdef NWINDOWS
+ #define SIGNAL(SIG) \
+   (void) signal (SIG, SIG ## _handler); \
+   SIG ## _handler = 0;
+@@ -47,16 +58,19 @@ SIGNALS
+     (void) signal (SIGALRM, SIGALRM_handler),
+     SIGALRM_handler = 0,
+     alarmset = false;
++#endif
+   solver = 0;
+   catchedsig = 0;
+ }
+ 
+ const char * Signal::name (int sig) {
++#ifdef NWINDOWS
+ #define SIGNAL(SIG) \
+   if (sig == SIG) return # SIG;
+   SIGNALS
+ #undef SIGNAL
+   if (sig == SIGALRM) return "SIGALRM";
++#endif
+   return "UNKNOWN";
+ }
+ 
+@@ -89,10 +103,12 @@ SIGNALS
+ }
+ 
+ void Signal::alarm (int seconds) {
++#ifdef NWINDOWS
+   assert (!alarmset);
+   SIGALRM_handler = signal (SIGALRM, Signal::catchsig);
+   alarmset = true;
+   ::alarm (seconds);
++#endif
+ }
+ 
+ };

--- a/contrib/windows_patches/lingeling_03b4860.patch
+++ b/contrib/windows_patches/lingeling_03b4860.patch
@@ -1,0 +1,130 @@
+diff --git a/lglib.c b/lglib.c
+--- a/lglib.c
++++ b/lglib.c
+@@ -20,7 +20,9 @@
+ #include <stdio.h>
+ #include <stdlib.h>
+ #include <string.h>
++#ifdef NWINDOWS
+ #include <sys/resource.h>
++#endif
+ #include <sys/time.h>
+ #include <unistd.h>
+ #include <stddef.h>
+@@ -1289,12 +1291,15 @@ static void lglogstart (LGL * lgl, int level, const char * msg, ...) {
+ /*------------------------------------------------------------------------*/
+ 
+ double lglprocesstime (void) {
++#ifdef NWINDOWS
+   struct rusage u;
+   double res;
+   if (getrusage (RUSAGE_SELF, &u)) return 0;
+   res = u.ru_utime.tv_sec + 1e-6 * u.ru_utime.tv_usec;
+   res += u.ru_stime.tv_sec + 1e-6 * u.ru_stime.tv_usec;
+   return res;
++#endif
++  return 0;
+ }
+ 
+ static double lglgetime (LGL * lgl) {
+diff --git a/lglib.h b/lglib.h
+index c5c89cc..b034334 100644
+--- a/lglib.h
++++ b/lglib.h
+@@ -6,7 +6,8 @@
+ #define lglib_h_INCLUDED
+ 
+ #include <stdio.h>				// for 'FILE'
+-#include <stdlib.h>				// for 'int64_t'
++#include <stdlib.h>
++#include <stdint.h>				// for 'int64_t'
+ 
+ //--------------------------------------------------------------------------
+ 
+diff --git a/lglmain.c b/lglmain.c
+index 2dc2b67..36c61d2 100644
+--- a/lglmain.c
++++ b/lglmain.c
+@@ -31,7 +31,9 @@ static void resetsighandlers (void) {
+   (void) signal (SIGSEGV, sig_segv_handler);
+   (void) signal (SIGABRT, sig_abrt_handler);
+   (void) signal (SIGTERM, sig_term_handler);
++#ifdef NWINDOWS
+   (void) signal (SIGBUS, sig_bus_handler);
++#endif
+ }
+ 
+ static void caughtsigmsg (int sig) {
+@@ -42,8 +44,10 @@ static void caughtsigmsg (int sig) {
+     case SIGSEGV: printf (" SIGSEGV"); break;
+     case SIGABRT: printf (" SIGABRT"); break;
+     case SIGTERM: printf (" SIGTERM"); break;
++#ifdef NWINDOWS
+     case SIGBUS: printf (" SIGBUS"); break;
+     case SIGALRM: printf (" SIGALRM"); break;
++#endif
+     default: break;
+   }
+   printf ("\nc\n");
+@@ -71,12 +75,15 @@ static void setsighandlers (void) {
+   sig_segv_handler = signal (SIGSEGV, catchsig);
+   sig_abrt_handler = signal (SIGABRT, catchsig);
+   sig_term_handler = signal (SIGTERM, catchsig);
++#ifdef NWINDOWS
+   sig_bus_handler = signal (SIGBUS, catchsig);
++#endif
+ }
+ 
+ static int timelimit = -1, caughtalarm = 0;
+ 
+ static void catchalrm (int sig) {
++#ifdef NWINDOWS
+   assert (sig == SIGALRM);
+   if (!caughtalarm) {
+     caughtalarm = 1;
+@@ -87,6 +94,7 @@ static void catchalrm (int sig) {
+       fflush (stdout);
+     }
+   }
++#endif
+ }
+ 
+ static int checkalarm (void * ptr) {
+@@ -513,8 +521,10 @@ ERR:
+       fflush (stdout);
+     }
+     lglseterm (lgl, checkalarm, &caughtalarm);
++#ifdef NWINDOWS
+     sig_alrm_handler = signal (SIGALRM, catchalrm);
+     alarm (timelimit);
++#endif
+   }
+   for (i = 0; i < ntargets; i++) lglassume (lgl, targets[i]);
+   if (simplevel > 0) {
+@@ -532,7 +542,9 @@ ERR:
+   res = lglsat (lgl);
+   if (timelimit >= 0) {
+     caughtalarm = 0;
++#ifdef NWINDOWS
+     (void) signal (SIGALRM, sig_alrm_handler);
++#endif
+   }
+   if (oname) {
+     double start = lglsec (lgl), delta;
+diff --git a/makefile.in b/makefile.in
+index 4914087..7148dea 100644
+--- a/makefile.in
++++ b/makefile.in
+@@ -15,8 +15,10 @@ all: targets
+ -include makefile.other
+ 
+ targets: liblgl.a
+-targets: lingeling plingeling ilingeling treengeling
+-targets: lglmbt lgluntrace lglddtrace
++targets: lingeling
++# targets: plingeling ilingeling treengeling
++# targets: lglmbt
++# targets: lgluntrace lglddtrace
+ targets: @AIGERTARGETS@
+ 
+ analyze:

--- a/contrib/windows_patches/picosat-965.patch
+++ b/contrib/windows_patches/picosat-965.patch
@@ -1,0 +1,59 @@
+diff -bur picosat-965/app.c picosat-965_windows/app.c
+--- picosat-965/app.c	2016-01-13 07:19:13.000000000 +0000
++++ picosat-965_windows/app.c	2018-08-14 15:48:55.470486400 +0100
+@@ -397,12 +397,14 @@
+ static void
+ alarm_triggered (int sig)
+ {
++#ifdef NWINDOWS
+   (void) sig;
+   assert (sig == SIGALRM);
+   assert (time_limit_in_seconds);
+   assert (!ought_to_be_interrupted);
+   ought_to_be_interrupted = 1;
+   assert (!interrupt_notified);
++#endif
+ }
+ 
+ static int
+@@ -429,18 +431,22 @@
+ static void
+ setalarm ()
+ {
++#ifdef NWINDOWS
+   assert (time_limit_in_seconds > 0);
+   sig_alarm_handler = signal (SIGALRM, alarm_triggered);
+   alarm (time_limit_in_seconds);
+   assert (picosat);
+   picosat_set_interrupt (picosat, 0, interrupt_call_back);
++#endif
+ }
+ 
+ static void
+ resetalarm ()
+ {
++#ifdef NWINDOWS
+   assert (time_limit_in_seconds > 0);
+   (void) signal (SIGALRM, sig_term_handler);
++#endif
+ }
+ 
+ static void
+diff -bur picosat-965/configure.sh picosat-965_windows/configure.sh
+--- picosat-965/configure.sh	2016-01-13 07:19:13.000000000 +0000
++++ picosat-965_windows/configure.sh	2018-08-14 15:48:03.798262200 +0100
+@@ -77,12 +77,13 @@
+ 
+ [ "X$CC" = X ] && CC=gcc
+ 
+-if [ X"$CFLAGS" = X ]
++if [ TRUE ]
+ then
+   case X"$CC" in
+     *wine*|*mingw*) CFLAGS="-DNGETRUSAGE -DNALLSIGNALS";;
+     *);;
+   esac
++  CFLAGS="$CFLAGS -DNGETRUSAGE -DNALLSIGNALS"
+   [ $log = yes ] && CFLAGS="$CFLAGS -DLOGGING"
+   [ $stats = yes ] && CFLAGS="$CFLAGS -DSTATS"
+   [ $trace = yes ] && CFLAGS="$CFLAGS -DTRACE"

--- a/src/api/python/CMakeLists.txt
+++ b/src/api/python/CMakeLists.txt
@@ -30,5 +30,10 @@ add_library(pyboolector
 add_dependencies(pyboolector pyboolector_options)
 
 target_link_libraries(pyboolector boolector ${PYTHON_LIBRARIES})
+
+if(IS_WINDOWS_BUILD)
+  target_link_libraries(pyboolector -static gcc stdc++ winpthread -dynamic)
+endif()
+
 python_extension_module(pyboolector)
 install(TARGETS pyboolector DESTINATION lib)


### PR DESCRIPTION
This PR contains three changes:

* A set of documentation steps that cover how to build (32-bit) Boolector when using MinGW
* A set of patches that modify Boolector's dependencies such that they also build on Windows
* Modifications to Boolector's CMakeLists (for pyboolector) to support static linking on Windows
* Modifications to Boolector's "setup" scripts to automatically apply the Windows patches when building on Windows