### PR TITLE
Compile minisat with -fPIC

### DIFF
--- a/contrib/setup-minisat.sh
+++ b/contrib/setup-minisat.sh
@@ -12,4 +12,4 @@ MINISAT_DIR=${SETUP_DIR}/minisat
 # Download and build MiniSat
 git clone --depth 1 https://github.com/niklasso/minisat.git ${MINISAT_DIR}
 cd ${MINISAT_DIR}
-make -j${NPROC}
+make -j${NPROC} CXXFLAGS=-fPIC


### PR DESCRIPTION
The Python bindings failed to build after using ./contrib/setup-minisat.sh because it compiled without -fPIC. This just adds -fPIC to the CXXFLAGS when compiling minisat.