### PR TITLE
Exposing Boolector's "version id" over the API

### DIFF
--- a/examples/api/python/api_usage_examples.py
+++ b/examples/api/python/api_usage_examples.py
@@ -5,6 +5,7 @@ from pyboolector import Boolector, BoolectorException
 if __name__ == "__main__":
     b = Boolector() 
     print ("Boolector version " + b.Version())
+    print ("Boolector id " + b.GitId())
     print ()
     print (b.Copyright())
 

--- a/src/api/python/btorapi.pxd
+++ b/src/api/python/btorapi.pxd
@@ -591,3 +591,6 @@ cdef extern from "boolector.h":
 
     const char * boolector_version (Btor * btor) \
       except +raise_py_error
+
+    const char * boolector_git_id (Btor * btor) \
+      except +raise_py_error

--- a/src/api/python/pyboolector.pyx
+++ b/src/api/python/pyboolector.pyx
@@ -696,6 +696,11 @@ cdef class Boolector:
             c_str = btorapi.boolector_version(self._c_btor)
             return _to_str(c_str)
 
+    def GitId(self):
+            cdef const char * c_str
+            c_str = btorapi.boolector_git_id(self._c_btor)
+            return _to_str(c_str)
+
     def Push(self, uint32_t levels = 1):
         """ Push(level)
 

--- a/src/boolector.c
+++ b/src/boolector.c
@@ -4735,3 +4735,11 @@ boolector_version (Btor *btor)
   BTOR_ABORT_ARG_NULL (btor);
   return btor_version (btor);
 }
+
+const char *
+boolector_git_id (Btor *btor)
+{
+  /* do not trace, not necessary */
+  BTOR_ABORT_ARG_NULL (btor);
+  return btor_git_id (btor);
+}

--- a/src/boolector.h
+++ b/src/boolector.h
@@ -2377,6 +2377,14 @@ const char *boolector_copyright (Btor *btor);
 */
 const char *boolector_version (Btor *btor);
 
+/*!
+  Get Boolector's git id string.
+
+  :param btor: Boolector instance.
+  :return: A string with Boolector's git id.
+*/
+const char *boolector_git_id (Btor *btor);
+
 /*------------------------------------------------------------------------*/
 #if __cplusplus
 }

--- a/src/btorcore.c
+++ b/src/btorcore.c
@@ -261,6 +261,14 @@ btor_version (const Btor *btor)
   return BTOR_VERSION;
 }
 
+const char *
+btor_git_id (const Btor *btor)
+{
+  assert (btor);
+  (void) btor;
+  return BTOR_GIT_ID;
+}
+
 BtorAIGMgr *
 btor_get_aig_mgr (const Btor *btor)
 {

--- a/src/btorcore.h
+++ b/src/btorcore.h
@@ -247,6 +247,9 @@ void btor_delete (Btor *btor);
 /* Gets version. */
 const char *btor_version (const Btor *btor);
 
+/* Gets id. */
+const char *btor_git_id (const Btor *btor);
+
 /* Set termination callback. */
 void btor_set_term (Btor *btor, int32_t (*fun) (void *), void *state);
 


### PR DESCRIPTION
For certain development/release scenarios, it would be beneficial to be able to get the git hash for the current build programmatically, as it is more granular that the Boolector version string.

This is something that is supported in Z3: https://github.com/Z3Prover/z3/commit/3587baaf24e001e3d88d49395357a826f743a189

and in STP: https://github.com/stp/stp/blob/master/lib/Util/GitSHA1.cpp.in

This PR exposes `BTOR_ID` over the C API and the Python API.