### PR TITLE
Options iteration when tracing is enabled

### DIFF
--- a/examples/api/python/api_usage_examples.py
+++ b/examples/api/python/api_usage_examples.py
@@ -411,3 +411,9 @@ if __name__ == "__main__":
     res       = bbb.Sat()
     if res == bbb.SAT: print("result: SAT")
     else             : print("result: UNSAT")
+
+### Check tracing API
+    os.environ["BTORAPITRACE"] = "btor.trace"
+    bbbb = Boolector()
+    print("Available Boolector options:")
+    print("\n".join(["  " + str(o) for o in b.Options()]))

--- a/src/boolector.c
+++ b/src/boolector.c
@@ -1092,7 +1092,7 @@ boolector_has_opt (Btor *btor, BtorOption opt)
 {
   bool res;
   BTOR_ABORT_ARG_NULL (btor);
-  BTOR_TRAPI ("%s", btor_opt_get_lng (btor, opt));
+  BTOR_TRAPI ("%s", opt == BTOR_OPT_NUM_OPTS ? "BTOR_OPT_NUM_OPTS" : btor_opt_get_lng (btor, opt));
   res = btor_opt_is_valid (btor, opt);
   BTOR_TRAPI_RETURN_BOOL (res);
 #ifndef NDEBUG


### PR DESCRIPTION
When running with `BTORAPITRACE`, Boolector crashes on any functionality that iterates over options (e.g., running `--help` or using the Python API).

The flow is (similar) to this:

* `export BTORAPITRACE="temp"`

* run `boolector --help`

* `main` -> `boolector_main` -> `print_help`

* `print_help` iterates over the options, and hits: `boolector_next_opt` (for the last option) and then goes around the loop and tries to run `boolector_has_opt` with `o` == `BTOR_OPT_NUM_OPTS`

* **If** tracing is enabled, then `boolector_has_opt` calls `btor_opt_get_lng`, which in turn calls `btor_opt_is_valid` -- if the option is not **strictly less than** `BTOR_OPT_NUM_OPTS`, then there is an assertion failure!

This bug is more obviously exposed when using the Python API. When using the Python API, creating a `Boolector()` instance leads to an instantiation of `BoolectorOptions`, which is iterated over to construct `self._option_names` in the `Boolector` class (`pyboolector.pyx`). Eventually this iteration gets close enough to `BTOR_OPT_NUM_OPTS`, that the same assertion fails.

The solution here was to make `boolector_has_opt` check if the current option is `BTOR_OPT_NUM_OPTS` before calling `btor_opt_get_lng`.

