### PR TITLE
Initial version of Dockerfile for Boolector

### DIFF
--- a/contrib/docker/DOCKER.md
+++ b/contrib/docker/DOCKER.md
@@ -1,0 +1,99 @@
+# Using Boolector with Docker
+
+Boolector has support for executing Boolector "input files" (e.g., `.smt2`)
+files via the use of a Docker container. The base container used is Alpine
+Linux.
+
+This guide presumes you are familiar with both Docker and Boolector, and are
+able to install the necessary prerequisites to run Docker.
+
+
+## Building the Docker image
+
+To build the Docker image locally, you can perform the following:
+
+```
+git clone https://github.com/Boolector/boolector.git
+cd boolector/contrib/docker
+docker build -t btor/btor .
+```
+
+This will then build you a fresh Docker image, with Boolector built inside.
+
+
+## Using Docker to run `.smt2` files
+
+As Boolector is able to read SMT2LIB files via `stdin`, this means that it is
+extremely easy to run Boolector against a `.smt2` file. For example:
+
+```
+#
+# Presuming you're at the root of a Boolector clone
+#
+cat src/tests/log/modelgensmt227.smt2 | docker run -i --rm btor/btor -m
+```
+
+Alternatively, to see Boolector's help:
+
+```
+docker run -i --rm btor/btor --help
+```
+
+*Note*: the `ENTRYPOINT` specified in the Boolector `Dockerfile` tells it to run
+`boolector` without any arguments. You can specify additional arguments to
+Boolector via your Docker `run` command.
+
+### Sharing files to the container
+
+The Boolector Docker image (by default) does not have access to your "host"
+file-system, which is why `cat` was necessary to pipe in the contents of your
+`.smt2` file into the image.
+
+If you wish to allow the containerised version of Boolector to able to read
+files from the host file-system, you can use Docker's `-v` flag to mount a
+shared volume:
+
+```
+#
+# Presuming you're at the root of a Boolector clone
+#
+docker run --rm -i -v $(pwd):/tmp btor/btor -m /tmp/src/tests/log/modelgensmt227.smt2
+```
+
+*Note*: the current working directory (`pwd`) has been mapped to `/tmp` within
+the container -- hence why the file-path to the SMT2LIB file you wish to run
+starts with `/tmp`.
+
+
+## Using Docker to work with Boolector's Python API
+
+The Boolector Docker image has been built with support for Boolector's Python
+API, however as the entry-point for the image is to run `boolector` (the
+application), then slightly more work is required to work with Python inside of
+the container:
+
+```
+#
+# Presuming you're at the root of a Boolector clone
+#
+docker run -it -v $(pwd):/tmp --entrypoint=/bin/bash btor/btor -i
+
+#
+# You are now inside of the container!!!
+#
+
+#
+# Run a Python script using pyboolector
+#
+python /tmp/examples/api/python/api_usage_examples.py
+
+#
+# Leave the container!!!
+#
+exit
+```
+
+*Note*: if you wish to use the containerised Python directly with files on your
+host file-system, you can customise the `ENTRYPOINT` specified in Boolector's
+`Dockerfile` (i.e., rather than running `boolector`, you can run `python`).
+

--- a/contrib/docker/Dockerfile
+++ b/contrib/docker/Dockerfile
@@ -1,0 +1,93 @@
+##############################################################################
+#                                                                            #
+# *Notice*                                                                   #
+#                                                                            #
+# This Docker image is based on Alpine Linux, which is a `musl` libc-based   #
+# distribution, and not `glibc`-based (e.g., like Ubuntu or Debian).         #
+#                                                                            #
+# To make Boolector work under `musl`, Boolector is "patched" using the      #
+# Windows patch-sets. These patch-sets (predominantly) are used to restrict  #
+# Boolector to the minimum amount of libc that is exposed via MinGW.         #
+#                                                                            #
+# For our purposes, restricting Boolector to the MinGW runtime also means    #
+# that Boolector builds and runs under `musl`.                               #
+#                                                                            #
+# Any references to patching "for Windows" should be read as "patching for   #
+# a minimal libc".                                                           #
+#                                                                            #
+##############################################################################
+
+FROM alpine:3.9
+
+MAINTAINER Andrew V. Jones "andrew.jones@vector.com"
+
+ENV LC_ALL en_US.UTF-8
+ENV LANG en_US.UTF-8
+
+#
+# Deps needed only for build
+#
+ENV BUILD_DEPS \
+    alpine-sdk \
+    cmake \
+    cython \
+    cython-dev \
+    g++ \
+    gcc \
+    git \
+    make \
+    python-dev \
+    sed
+
+#
+# Deps needed for running afterwards
+#
+ENV PERSISTENT_DEPS \
+    bash \
+    libgcc \
+    libstdc++ \
+    python
+
+#
+# Steps to build-up our image
+#
+RUN apk upgrade --update && \
+    apk add --no-cache --virtual .build-deps $BUILD_DEPS && \
+    apk add --no-cache --virtual .persistent-deps $PERSISTENT_DEPS && \
+    # \
+    # Musl does not provide /usr/include/sys/unistd.h, which Lingeling needs \
+    # \
+    echo "#include <unistd.h>" > /usr/include/sys/unistd.h && \
+    git clone https://github.com/Boolector/boolector.git && \
+    cd boolector && \
+    # \
+    # Musl does not provide quite enough of glibc, so we pretend we're Windows \
+    # \
+    sed -i "s#MINGW32#Linux#g" ./contrib/setup-btor2tools.sh && \
+    sed -i "s#MINGW32#Linux#g" ./contrib/setup-lingeling.sh && \
+    sed -i "s#MINGW32#Linux#g" ./contrib/setup-picosat.sh && \
+    sed -i "s#MINGW32#Linux#g" ./contrib/setup-cadical.sh && \
+    ./contrib/setup-btor2tools.sh && \
+    ./contrib/setup-picosat.sh && \
+    ./contrib/setup-cadical.sh && \
+    ./contrib/setup-lingeling.sh && \
+    ./configure.sh --python --shared && \
+    cd build && \
+    make -j$(nproc) && \
+    # \
+    # Validate our build of Boolector \
+    # \
+    ./bin/test && \
+    apk del .build-deps
+
+#
+# When we're in the container, we want to have PYTHONPATH to include pyboolector
+#
+ENV PYTHONPATH "${PYTHONPATH}:/boolector/build/lib"
+
+#
+# Entry point to allow us to run .smt2 files "from the outside"
+#
+ENTRYPOINT ["/boolector/build/bin/boolector"]
+
+# EOF


### PR DESCRIPTION
Extremely simple "v0.1" of a Dockerfile that supports building and working with Boolector via a container.

**This PR relies on PR #40, otherwise PicoSAT does not correct build under Docker.**
