### PR TITLE
When building statically, prefer PicoSAT's archives over its shared objects

### DIFF
--- a/cmake/FindPicoSAT.cmake
+++ b/cmake/FindPicoSAT.cmake
@@ -4,7 +4,11 @@
 # PicoSAT_LIBRARIES - Libraries needed to use PicoSAT
 
 find_path(PicoSAT_INCLUDE_DIR NAMES picosat.h)
-find_library(PicoSAT_LIBRARIES NAMES picosat)
+if(NOT SHARED)
+  find_library(PicoSAT_LIBRARIES NAMES libpicosat.a picosat)
+else()
+  find_library(PicoSAT_LIBRARIES NAMES picosat)
+endif()
 
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(PicoSAT


### PR DESCRIPTION
Currently, when building Boolector with its Python modules, you can only link against PicoSAT if you build a shared (i.e., dynamically linked) Boolector.

This PR modifies Boolector's build system such that you can link PicoSAT even when building Boolector's Python module _and_ linking statically.

It is worth noting that `contrib/setup-picosat.sh` already builds `libpicosat.a` and `libpicosat.so`. All this PR does is prefer linking `libpicosat.a` over `libpicosat.so`, when building statically.