### PR TITLE
Check that "-Wl,--no-export-dynamic" is a supported link flag before using it

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -252,6 +252,8 @@ if(TIME_STATS)
   add_definitions("-DBTOR_TIME_STATISTICS")
 endif()
 
+include(CheckNoExportDynamic)
+
 #-----------------------------------------------------------------------------#
 
 if(ONLY_CADICAL)

--- a/cmake/CheckNoExportDynamic.cmake
+++ b/cmake/CheckNoExportDynamic.cmake
@@ -1,0 +1,6 @@
+# Check if the linker flag no-export-dynamic is supported
+include(CheckCSourceCompiles)
+
+set(CMAKE_REQUIRED_FLAGS "-Wl,--no-export-dynamic")
+check_c_compiler_flag("" HAVE_NO_EXPORT_DYNAMIC)
+unset(CMAKE_REQUIRED_FLAGS)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -130,9 +130,13 @@ set_target_properties(boolector-bin
     OUTPUT_NAME boolector
     RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 if(NOT BUILD_SHARED_LIBS AND NOT APPLE)
+  set(BTOR_STATIC_FLAGS "-static")
+  if(HAVE_NO_EXPORT_DYNAMIC)
+    set(BTOR_STATIC_FLAGS "${BTOR_STATIC_FLAGS} -Wl,--no-export-dynamic")
+  endif()
   set_target_properties(boolector-bin
     PROPERTIES
-      LINK_FLAGS "-static -Wl,--no-export-dynamic"
+      LINK_FLAGS ${BTOR_STATIC_FLAGS}
       LINK_SEARCH_START_STATIC ON LINK_SEARCH_END_STATIC ON)
 endif()
 install(TARGETS boolector-bin DESTINATION bin)


### PR DESCRIPTION
Currently, Boolector's build process uses the linker flag `-Wl,--no-export-dynamic` without checking if it is supported by the underlying compiler.

This PR adds a CMake "check" module to validate that this linker flag is supported, before using it.

Note: there is no "built-in" CMake macro for checking if a linker flag is supported. The approach taken was there recommend approach from the CMake mailing list:

https://cmake.org/pipermail/cmake/2011-July/045525.html