### PR TITLE
Fixed cmake script + removed a compilation warning.

### DIFF
--- a/cmake/FindBtor2Tools.cmake
+++ b/cmake/FindBtor2Tools.cmake
@@ -3,12 +3,19 @@
 # Btor2Tools_INCLUDE_DIR - the Btor2Tools include directory
 # Btor2Tools_LIBRARIES - Libraries needed to use Btor2Tools
 
-find_path(Btor2Tools_INCLUDE_DIR NAMES btor2parser/btor2parser.h)
-find_library(Btor2Tools_LIBRARIES NAMES btor2parser)
+
+find_path(Btor2Tools_INCLUDE_DIR NAMES btor2parser/btor2parser.h
+				 PATHS ${Btor2Tools_ROOT_DIR}
+				 PATH_SUFFIXES src include)
+
+find_library(Btor2Tools_LIBRARIES NAMES btor2parser
+				  PATHS ${Btor2Tools_ROOT_DIR}
+				  PATH_SUFFIXES build lib)
+
 
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(Btor2Tools
-  DEFAULT_MSG Btor2Tools_INCLUDE_DIR Btor2Tools_LIBRARIES)
+   DEFAULT_MSG Btor2Tools_INCLUDE_DIR Btor2Tools_LIBRARIES)
 
 mark_as_advanced(Btor2Tools_INCLUDE_DIR Btor2Tools_LIBRARIES)
 if(Btor2Tools_LIBRARIES)

--- a/src/btormbt.c
+++ b/src/btormbt.c
@@ -217,8 +217,8 @@ void boolector_print_value_smt2 (Btor *, BoolectorNode *, char *, FILE *);
 
 #define BTORMBT_LOG_STATUS(l, prefix)                                      \
   BTORMBT_LOG (l,                                                          \
-               prefix " (%d): bool %" PRId64 ", bv %" PRId64               \
-                      ", array %" PRId64 ", fun %" PRId64 ", uf %" PRId64, \
+               prefix                                                      \
+               " (%d): bool %zu, bv %zu, array %zu, fun %zu, uf %zu",      \
                g_btormbt->round.ops,                                       \
                BTOR_COUNT_STACK (g_btormbt->bo->exps),                     \
                BTOR_COUNT_STACK (g_btormbt->bv->exps),                     \


### PR DESCRIPTION
Script cmake/FindBtor2Tools.cmake didn't take Btor2Tools_ROOT_DIR
into account. Something like "./configure.sh --btor2tools-dir <...>"
failed because of that.

Fixed a string format in btormbt.c to avoid compilation warnings.

Signed-off-by: Bruno Dutertre <bruno@csl.sri.com>