### PR TITLE
contrib: fix scripts

### DIFF
--- a/contrib/setup-all.sh
+++ b/contrib/setup-all.sh
@@ -1,4 +1,6 @@
-#!/bin/bash
+#!/usr/bin/env bash
+
+set -e -o pipefail
 
 ./contrib/setup-btor2tools.sh
 ./contrib/setup-cadical.sh

--- a/contrib/setup-btor2tools.sh
+++ b/contrib/setup-btor2tools.sh
@@ -1,4 +1,6 @@
-#!/bin/bash
+#!/usr/bin/env bash
+
+set -e -o pipefail
 
 source "$(dirname "$0")/setup-utils.sh"
 

--- a/contrib/setup-cadical.sh
+++ b/contrib/setup-cadical.sh
@@ -1,4 +1,6 @@
-#!/bin/bash
+#!/usr/bin/env bash
+
+set -e -o pipefail
 
 source "$(dirname "$0")/setup-utils.sh"
 

--- a/contrib/setup-lingeling.sh
+++ b/contrib/setup-lingeling.sh
@@ -1,4 +1,6 @@
-#!/bin/bash
+#!/usr/bin/env bash
+
+set -e -o pipefail
 
 source "$(dirname "$0")/setup-utils.sh"
 

--- a/contrib/setup-minisat.sh
+++ b/contrib/setup-minisat.sh
@@ -1,4 +1,6 @@
-#!/bin/bash
+#!/usr/bin/env bash
+
+set -e -o pipefail
 
 source "$(dirname "$0")/setup-utils.sh"
 

--- a/contrib/setup-picosat.sh
+++ b/contrib/setup-picosat.sh
@@ -1,4 +1,6 @@
-#!/bin/bash
+#!/usr/bin/env bash
+
+set -e -o pipefail
 
 source "$(dirname "$0")/setup-utils.sh"
 

--- a/contrib/setup-utils.sh
+++ b/contrib/setup-utils.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This script defines common utility functions used by the contrib/setup-*.sh
 # scripts.


### PR DESCRIPTION
The `contrib/setup-*` scripts are currently broken in the following two ways:

 - hardcoded `/bin/bash` interpreter path, which is not true on all systems (BSDs, and non-FHS Linux distributions like NixOS)
 - no `-e -o pipefail`, causing any failures within the contrib build machinery to fail silently instead of bubbling up to the caller

This change addresses the above issues.