### PR TITLE
Updating CaDiCaL patches for the latest version

### DIFF
--- a/contrib/setup-cadical.sh
+++ b/contrib/setup-cadical.sh
@@ -12,7 +12,7 @@ cd ${CADICAL_DIR}
 
 if is_windows; then
   component="CaDiCaL"
-  last_patch_date="20190623"
+  last_patch_date="20190730"
   test_apply_patch "${component}" "${last_patch_date}"
   EXTRA_FLAGS="-q"
   #

--- a/contrib/windows_patches/CaDiCaL_20190730.patch
+++ b/contrib/windows_patches/CaDiCaL_20190730.patch
@@ -1,21 +1,5 @@
-diff --git a/src/analyze.cpp b/src/analyze.cpp
-index 05d76e2..4786699 100644
---- a/src/analyze.cpp
-+++ b/src/analyze.cpp
-@@ -280,9 +280,9 @@ void Internal::clear_analyzed_levels () {
- struct analyze_trail_negative_rank {
-   Internal * internal;
-   analyze_trail_negative_rank (Internal * s) : internal (s) { }
--  size_t operator () (int a) {
-+  uint64_t operator () (int a) {
-     Var & v = internal->var (a);
--    size_t res = v.level;
-+    uint64_t res = v.level;
-     res <<= 32;
-     res |= v.trail;
-     return ~res;
 diff --git a/src/mobical.cpp b/src/mobical.cpp
-index d80bb01..e809b0c 100644
+index 52f3b83..217f359 100644
 --- a/src/mobical.cpp
 +++ b/src/mobical.cpp
 @@ -693,8 +693,12 @@ public:
@@ -31,7 +15,7 @@ index d80bb01..e809b0c 100644
  #define SIGNAL(SIG) \
    static void (*old_ ## SIG ## _handler) (int);
    SIGNALS
-@@ -1413,8 +1417,10 @@ extern "C" {
+@@ -1414,8 +1418,10 @@ extern "C" {
  #include <fcntl.h>
  #include <sys/stat.h>
  #include <sys/types.h>
@@ -42,15 +26,15 @@ index d80bb01..e809b0c 100644
  #include <sys/time.h>
  }
  
-@@ -1436,6 +1442,7 @@ void Trace::reset_child_signal_handlers () {
+@@ -1437,6 +1443,7 @@ void Trace::reset_child_signal_handlers () {
  }
  
  void Trace::child_signal_handler (int sig) {
 +#ifdef NWINDOWS
    struct rusage u;
    if (!getrusage (RUSAGE_SELF, &u)) {
-     if ((long) u.ru_maxrss >> 10 >= mobical.space_limit) {
-@@ -1454,6 +1461,7 @@ void Trace::child_signal_handler (int sig) {
+     if ((int64_t) u.ru_maxrss >> 10 >= mobical.space_limit) {
+@@ -1455,6 +1462,7 @@ void Trace::child_signal_handler (int sig) {
    }
    reset_child_signal_handlers ();
    raise (sig);
@@ -58,7 +42,7 @@ index d80bb01..e809b0c 100644
  }
  
  void Trace::init_child_signal_handlers () {
-@@ -1466,11 +1474,16 @@ void Trace::init_child_signal_handlers () {
+@@ -1467,11 +1475,16 @@ void Trace::init_child_signal_handlers () {
  int Trace::fork_and_execute () {
  
    cerr << flush;
@@ -77,7 +61,7 @@ index d80bb01..e809b0c 100644
      executed++;
  
      int status, other = wait (&status);
-@@ -1479,23 +1492,28 @@ int Trace::fork_and_execute () {
+@@ -1480,23 +1493,28 @@ int Trace::fork_and_execute () {
      else if (!WIFSIGNALED (status)) res = 0;
      else if (mobical.donot.ignore_resource_limits) res = 1;
      else res = (WTERMSIG (status) != SIGXCPU);
@@ -106,7 +90,7 @@ index d80bb01..e809b0c 100644
      }
  
      init_child_signal_handlers ();
-@@ -2479,7 +2497,9 @@ void Mobical::header () {
+@@ -2480,7 +2498,9 @@ void Mobical::header () {
  /*------------------------------------------------------------------------*/
  
  extern "C" {
@@ -116,7 +100,7 @@ index d80bb01..e809b0c 100644
  }
  
  Mobical::Mobical ()
-@@ -2503,13 +2523,17 @@ Mobical::Mobical ()
+@@ -2504,13 +2524,17 @@ Mobical::Mobical ()
    traces (0),
    spurious (0)
  {
@@ -134,9 +118,9 @@ index d80bb01..e809b0c 100644
  }
  
  void Mobical::catch_signal (int) {
-@@ -2533,6 +2557,10 @@ int Mobical::main (int argc, char ** argv) {
+@@ -2534,6 +2558,10 @@ int Mobical::main (int argc, char ** argv) {
  
-   long limit = -1;
+   int64_t limit = -1;
  
 +#ifndef NWINDOWS
 +  donot.fork = true;
@@ -146,7 +130,7 @@ index d80bb01..e809b0c 100644
    //
    for (int i = 1; i < argc; i++)
 diff --git a/src/resources.cpp b/src/resources.cpp
-index 06c8c87..ea3263c 100644
+index b21416d..d0b91c6 100644
 --- a/src/resources.cpp
 +++ b/src/resources.cpp
 @@ -7,7 +7,9 @@
@@ -196,10 +180,10 @@ index 06c8c87..ea3263c 100644
  size_t current_resident_set_size () {
 +#ifdef NWINDOWS
    char path[40];
-   sprintf (path, "/proc/%ld/statm", (long) getpid ());
+   sprintf (path, "/proc/%" PRId64 "/statm", (int64_t) getpid ());
    FILE * file = fopen (path, "r");
 @@ -70,6 +81,9 @@ size_t current_resident_set_size () {
-   int scanned = fscanf (file, "%ld %ld", &dummy, &rss);
+   int scanned = fscanf (file, "%" PRId64 " %" PRId64 "", &dummy, &rss);
    fclose (file);
    return scanned == 2 ? rss * sysconf (_SC_PAGESIZE) : 0;
 +#else


### PR DESCRIPTION
Updated Windows patches for the most recent version of CaDiCaL. Ran both the CaDiCaL and Boolector (up until the incremental ones failed) tests successfully on Windows 32.

Signed-off-by: Andrew V. Jones <andrew.joes@vector.com>