### PR TITLE
Removing '-ha' from btormbt's help

### DIFF
--- a/src/btormbt.c
+++ b/src/btormbt.c
@@ -187,7 +187,6 @@ void boolector_print_value_smt2 (Btor *, BoolectorNode *, char *, FILE *);
   "where <option> is one of the following:\n"                                  \
   "\n"                                                                         \
   "  -h, --help                  print this message and exit\n"                \
-  "  -ha                         print all options\n"                          \
   "\n"                                                                         \
   "  -v                          be extra verbose\n"                           \
   "  -q                          be extra quiet (stats only)\n"                \


### PR DESCRIPTION
Commit [9bda7c8](https://github.com/Boolector/boolector/commit/9bda7c88cac86015217f486786076d2c6197afa7) removed the ability to run `btormbt -ha`, but did not remove `-ha` from the help print.

This PR fixes that.

Signed-off-by: Andrew V. Jones <andrew.jones@vector.com>