### PR TITLE
Instructions and fixes for a 64-bit Windows build

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,11 +126,10 @@ find_package(Boolector)
 target_link_libraries(<your_target> Boolector::boolector)
 ```
 
-### Windows 32-bit on Windows 64-bit
+### Windows
 
-For build and installation instructions of a Boolector Windows 32-bit build
-on a Windows 64-bit system, see file [COMPILING_WIN32.md](
-    https://github.com/Boolector/boolector/blob/master/COMPILING_WIN32.md).
+For build and installation instructions of a Boolector Windows 64-bit build, see file [COMPILING_WIN64.md](
+    https://github.com/Boolector/boolector/blob/master/COMPILING_WIN64.md).
 
 ## Usage
 

--- a/contrib/setup-cadical.sh
+++ b/contrib/setup-cadical.sh
@@ -7,7 +7,13 @@ source "$(dirname "$0")/setup-utils.sh"
 CADICAL_DIR=${DEPS_DIR}/cadical
 COMMIT_ID="cb89cbfa16f47cb7bf1ec6ad9855e7b6d5203c18"
 
-download_github "arminbiere/cadical" "$COMMIT_ID" "$CADICAL_DIR"
+TAR_ARGS=""
+if is_windows; then
+  # Extracting a symlink to a non-existing file fails on Windows, so we exclude it
+  TAR_ARGS="--exclude src/makefile"
+fi
+
+download_github "arminbiere/cadical" "$COMMIT_ID" "$CADICAL_DIR" "$TAR_ARGS"
 cd ${CADICAL_DIR}
 
 if is_windows; then

--- a/contrib/setup-utils.sh
+++ b/contrib/setup-utils.sh
@@ -107,13 +107,14 @@ function download_github
   local repo="$1"
   local version="$2"
   local location="$3"
+  local tar_args="$4"
   local name=$(echo "$repo" | cut -d '/' -f 2)
   local archive="$name-$version.tar.gz"
 
   curl -o "$archive" -L "https://github.com/$repo/archive/$version.tar.gz"
 
   rm -rf "${location}"
-  tar xfvz "$archive"
+  tar xfvz "$archive" $tar_args
   rm "$archive"
   mv "$name-$version" "${location}"
 }


### PR DESCRIPTION
This adds a COMPILING_WIN64.md file, adapted from COMPILING_WIN32.md,
containing updated instructions for a 64-bit Windows build using
Python 3.

It also adds a workaround for building CaDiCaL on Windows. CaDiCaL's
source tar contains a symlink that cannot be extracted on Windows. The
build script now ignores that file when extracting on Windows, it isn't
required for a successful build.

The resulting build hasn't been tested extensively, but it successfully
runs the included Python API examples.

Signed-off-by: Jannis Harder <me@jix.one>