### PR TITLE
Correcting incorrect argument in documentation of 'Udiv'

### DIFF
--- a/src/api/python/pyboolector.pyx
+++ b/src/api/python/pyboolector.pyx
@@ -2366,7 +2366,7 @@ cdef class Boolector:
 
             Parameters ``a`` and ``b`` must have the same bit width
             (see :ref:`const-conversion`).
-            If ``a`` is 0, the division's result is -1.
+            If ``b`` is 0, the division's result is -1.
 
             It is also possible to create an unsigned division as follows
             (see :ref:`operator-overloading`): ::


### PR DESCRIPTION
Boolector's documentation for [`Udiv`](https://boolector.github.io/docs/boolector.html#pyboolector.Boolector.Udiv) incorrectly states that if the _first_ argument is 0, the encoding returns -1. This incorrect -- it is if the _second_ argument is 0, that the encoding will be -1.

Documentation has been corrected to address this issue.

Signed-off-by: Andrew V. Jones <andrew.jones@vector.com>