### PR TITLE
Ensuring copyright years in '-c' is up-to-date

### DIFF
--- a/src/boolector.c
+++ b/src/boolector.c
@@ -4914,7 +4914,7 @@ boolector_copyright (Btor *btor)
   return "This software is\n"
          "Copyright (c) 2007-2009 Robert Brummayer\n"
          "Copyright (c) 2007-2018 Armin Biere\n"
-         "Copyright (c) 2012-2019 Aina Niemetz, Mathias Preiner\n"
+         "Copyright (c) 2012-2020 Aina Niemetz, Mathias Preiner\n"
 #ifdef BTOR_USE_LINGELING
          "\n"
          "This software is linked against Lingeling\n"


### PR DESCRIPTION
I noticed that the Boolector copyright notice is out-of-date.

Given you've both committed in 2020, it should say 2020 not 2019.

Signed-off-by: Andrew V. Jones <andrew.jones@vector.com>