### PR TITLE
btormc: really stop at first reached property with --stop-first

### DIFF
--- a/src/btormc.c
+++ b/src/btormc.c
@@ -1409,6 +1409,9 @@ check_last_forward_frame (BtorMC *mc)
       {
         print_witness (mc, k, i);
       }
+
+      if (btor_mc_get_opt (mc, BTOR_MC_OPT_STOP_FIRST))
+        break;
     }
     else
     {


### PR DESCRIPTION
If a model contains multiple properties and the stop-first option is set, you can still get multiple witnesses returned when several properties are satisfiable in the same time step. This is inconvenient if you only want one result, especially as it takes extra time to check the others.

With this PR, instead break out of the loop after finding the first satisfied property.