### PR TITLE
Update setup-scripts of btor2tools and utils

### DIFF
--- a/contrib/setup-btor2tools.sh
+++ b/contrib/setup-btor2tools.sh
@@ -5,11 +5,9 @@ set -e -o pipefail
 source "$(dirname "$0")/setup-utils.sh"
 
 BTOR2TOOLS_DIR=${DEPS_DIR}/btor2tools
+COMMIT_ID="1df768d75adfb13a8f922f5ffdd1d58e80cb1cc2"
 
-rm -rf ${BTOR2TOOLS_DIR}
-
-# Download and build btor2tools
-git clone --depth 1 https://github.com/Boolector/btor2tools.git ${BTOR2TOOLS_DIR}
+download_github "boolector/btor2tools" "$COMMIT_ID" "$BTOR2TOOLS_DIR"
 cd ${BTOR2TOOLS_DIR}
 
 if is_windows; then

--- a/contrib/setup-utils.sh
+++ b/contrib/setup-utils.sh
@@ -101,3 +101,19 @@ function test_apply_patch
     exit 1
   fi
 }
+
+function download_github
+{
+  local repo="$1"
+  local version="$2"
+  local location="$3"
+  local name=$(echo "$repo" | cut -d '/' -f 2)
+  local archive="$name-$version.tar.gz"
+
+  curl -o "$archive" -L "https://github.com/$repo/archive/$version.tar.gz"
+
+  rm -rf "${location}"
+  tar xfvz "$archive"
+  rm "$archive"
+  mv "$name-$version" "${location}"
+}

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -7,6 +7,7 @@ set(libboolector_src_files
   btoraigvec.c
   btorass.c
   btorbeta.c
+  btorbitblast.c
   btorbv.c
   btorchkclone.c
   btorclone.c

--- a/src/aigprop.c
+++ b/src/aigprop.c
@@ -59,10 +59,10 @@ aigprop_get_assignment_aig (AIGProp *aprop, BtorAIG *aig)
   if (btor_aig_is_true (aig)) return 1;
   if (btor_aig_is_false (aig)) return -1;
 
-  id = btor_aig_get_id (BTOR_REAL_ADDR_AIG (aig));
+  id = btor_aig_get_id (btor_aig_real_addr (aig));
   assert (btor_hashint_map_get (aprop->model, id));
   res = btor_hashint_map_get (aprop->model, id)->as_int;
-  res = BTOR_IS_INVERTED_AIG (aig) ? -res : res;
+  res = btor_aig_is_inverted (aig) ? -res : res;
   return res;
 }
 
@@ -84,31 +84,31 @@ aigprop_get_assignment_aig (AIGProp *aprop, BtorAIG *aig)
     assert (a);                                                      \
     AIGPROPLOG (3,                                                   \
                 "        assignment aig0 (%s%d): %d",                \
-                BTOR_IS_INVERTED_AIG (left) ? "-" : "",              \
-                BTOR_REAL_ADDR_AIG (left)->id,                       \
+                btor_aig_is_inverted (left) ? "-" : "",              \
+                btor_aig_real_addr (left)->id,                       \
                 a < 0 ? 0 : 1);                                      \
     a = aigprop_get_assignment_aig (aprop, right);                   \
     assert (a);                                                      \
     AIGPROPLOG (3,                                                   \
                 "        assignment aig1 (%s%d): %d",                \
-                BTOR_IS_INVERTED_AIG (right) ? "-" : "",             \
-                BTOR_REAL_ADDR_AIG (right)->id,                      \
+                btor_aig_is_inverted (right) ? "-" : "",             \
+                btor_aig_real_addr (right)->id,                      \
                 a < 0 ? 0 : 1);                                      \
     AIGPROPLOG (3,                                                   \
                 "        score      aig0 (%s%d): %f%s",              \
-                BTOR_IS_INVERTED_AIG (left) ? "-" : "",              \
-                BTOR_REAL_ADDR_AIG (left)->id,                       \
+                btor_aig_is_inverted (left) ? "-" : "",              \
+                btor_aig_real_addr (left)->id,                       \
                 s0,                                                  \
                 s0 < 1.0 ? " (< 1.0)" : "");                         \
     AIGPROPLOG (3,                                                   \
                 "        score      aig1 (%s%d): %f%s",              \
-                BTOR_IS_INVERTED_AIG (right) ? "-" : "",             \
-                BTOR_REAL_ADDR_AIG (right)->id,                      \
+                btor_aig_is_inverted (right) ? "-" : "",             \
+                btor_aig_real_addr (right)->id,                      \
                 s1,                                                  \
                 s1 < 1.0 ? " (< 1.0)" : "");                         \
     AIGPROPLOG (3,                                                   \
                 "      * score cur (%s%d): %f%s",                    \
-                BTOR_IS_INVERTED_AIG (cur) ? "-" : "",               \
+                btor_aig_is_inverted (cur) ? "-" : "",               \
                 real_cur->id,                                        \
                 res,                                                 \
                 res < 1.0 ? " (< 1.0)" : "");                        \
@@ -145,7 +145,7 @@ compute_score_aig (AIGProp *aprop, BtorAIG *aig)
   while (!BTOR_EMPTY_STACK (stack))
   {
     cur      = BTOR_POP_STACK (stack);
-    real_cur = BTOR_REAL_ADDR_AIG (cur);
+    real_cur = btor_aig_real_addr (cur);
 
     if (btor_aig_is_const (real_cur)) continue;
 
@@ -179,7 +179,7 @@ compute_score_aig (AIGProp *aprop, BtorAIG *aig)
       AIGPROPLOG (3, "");
       AIGPROPLOG (3,
                   "  ** assignment cur (%s%d): %d",
-                  BTOR_IS_INVERTED_AIG (cur) ? "-" : "",
+                  btor_aig_is_inverted (cur) ? "-" : "",
                   real_cur->id,
                   a < 0 ? 0 : 1);
 #endif
@@ -191,12 +191,12 @@ compute_score_aig (AIGProp *aprop, BtorAIG *aig)
         res = aigprop_get_assignment_aig (aprop, cur) < 0 ? 0.0 : 1.0;
         AIGPROPLOG (3,
                     "        * score cur (%s%d): %f",
-                    BTOR_IS_INVERTED_AIG (cur) ? "-" : "",
+                    btor_aig_is_inverted (cur) ? "-" : "",
                     real_cur->id,
                     res);
         AIGPROPLOG (3,
                     "        * score cur (%s%d): %f",
-                    BTOR_IS_INVERTED_AIG (cur) ? "" : "-",
+                    btor_aig_is_inverted (cur) ? "" : "-",
                     real_cur->id,
                     res == 0.0 ? 1.0 : 0.0);
         btor_hashint_map_add (aprop->score, curid)->as_dbl = res;
@@ -248,9 +248,9 @@ compute_score_aig (AIGProp *aprop, BtorAIG *aig)
         assert (res >= 0.0 && res <= 1.0);
         btor_hashint_map_add (aprop->score, -real_cur->id)->as_dbl = res;
 #ifndef NDEBUG
-        AIGPROP_LOG_COMPUTE_SCORE_AIG (BTOR_INVERT_AIG (real_cur),
-                                       BTOR_INVERT_AIG (left),
-                                       BTOR_INVERT_AIG (right),
+        AIGPROP_LOG_COMPUTE_SCORE_AIG (btor_aig_invert (real_cur),
+                                       btor_aig_invert (left),
+                                       btor_aig_invert (right),
                                        sleft,
                                        sright,
                                        res);
@@ -301,7 +301,7 @@ compute_scores (AIGProp *aprop)
   while (!BTOR_EMPTY_STACK (stack))
   {
     cur      = BTOR_POP_STACK (stack);
-    real_cur = BTOR_REAL_ADDR_AIG (cur);
+    real_cur = btor_aig_real_addr (cur);
 
     if (btor_aig_is_const (real_cur)) continue;
     if (btor_hashint_map_contains (aprop->score, btor_aig_get_id (cur)))
@@ -318,11 +318,11 @@ compute_scores (AIGProp *aprop)
         right = btor_aig_get_right_child (aprop->amgr, real_cur);
         if (!btor_aig_is_const (left)
             && !btor_hashint_table_contains (cache,
-                                             BTOR_REAL_ADDR_AIG (left)->id))
+                                             btor_aig_real_addr (left)->id))
           BTOR_PUSH_STACK (stack, left);
         if (!btor_aig_is_const (right)
             && !btor_hashint_table_contains (cache,
-                                             BTOR_REAL_ADDR_AIG (right)->id))
+                                             btor_aig_real_addr (right)->id))
           BTOR_PUSH_STACK (stack, right);
       }
     }
@@ -363,7 +363,7 @@ recursively_compute_assignment (AIGProp *aprop, BtorAIG *aig)
   while (!BTOR_EMPTY_STACK (stack))
   {
     cur      = BTOR_POP_STACK (stack);
-    real_cur = BTOR_REAL_ADDR_AIG (cur);
+    real_cur = btor_aig_real_addr (cur);
     assert (!btor_aig_is_const (real_cur));
     if (btor_hashint_map_contains (aprop->model, real_cur->id)) continue;
 
@@ -384,11 +384,11 @@ recursively_compute_assignment (AIGProp *aprop, BtorAIG *aig)
         BTOR_PUSH_STACK (stack, cur);
         if (!btor_aig_is_const (left)
             && !btor_hashint_table_contains (cache,
-                                             BTOR_REAL_ADDR_AIG (left)->id))
+                                             btor_aig_real_addr (left)->id))
           BTOR_PUSH_STACK (stack, left);
         if (!btor_aig_is_const (right)
             && !btor_hashint_table_contains (cache,
-                                             BTOR_REAL_ADDR_AIG (right)->id))
+                                             btor_aig_real_addr (right)->id))
           BTOR_PUSH_STACK (stack, right);
       }
       else
@@ -471,7 +471,7 @@ update_unsatroots_table (AIGProp *aprop, BtorAIG *aig, int32_t assignment)
   else if (btor_hashint_map_contains (aprop->unsatroots, -id))
   {
     btor_hashint_map_remove (aprop->unsatroots, -id, 0);
-    assert (aigprop_get_assignment_aig (aprop, BTOR_INVERT_AIG (aig)) == -1);
+    assert (aigprop_get_assignment_aig (aprop, btor_aig_invert (aig)) == -1);
     assert (assignment == -1);
   }
   else if (assignment == -1)
@@ -482,7 +482,7 @@ update_unsatroots_table (AIGProp *aprop, BtorAIG *aig, int32_t assignment)
   else
   {
     btor_hashint_map_add (aprop->unsatroots, -id);
-    assert (aigprop_get_assignment_aig (aprop, BTOR_INVERT_AIG (aig)) == 1);
+    assert (aigprop_get_assignment_aig (aprop, btor_aig_invert (aig)) == 1);
   }
 }
 
@@ -491,7 +491,7 @@ update_cone (AIGProp *aprop, BtorAIG *aig, int32_t assignment)
 {
   assert (aprop);
   assert (aig);
-  assert (BTOR_IS_REGULAR_AIG (aig));
+  assert (btor_aig_is_regular (aig));
   assert (btor_aig_is_var (aig));
   assert (assignment == 1 || assignment == -1);
 
@@ -517,21 +517,21 @@ update_cone (AIGProp *aprop, BtorAIG *aig, int32_t assignment)
   {
     root = btor_aig_get_by_id (aprop->amgr, btor_iter_hashint_next (&it));
     assert (!btor_aig_is_false (root));
-    if ((!BTOR_IS_INVERTED_AIG (root)
-         && aigprop_get_assignment_aig (aprop, BTOR_REAL_ADDR_AIG (root)) == -1)
-        || (BTOR_IS_INVERTED_AIG (root)
-            && aigprop_get_assignment_aig (aprop, BTOR_REAL_ADDR_AIG (root))
+    if ((!btor_aig_is_inverted (root)
+         && aigprop_get_assignment_aig (aprop, btor_aig_real_addr (root)) == -1)
+        || (btor_aig_is_inverted (root)
+            && aigprop_get_assignment_aig (aprop, btor_aig_real_addr (root))
                    == 1))
     {
       assert (btor_hashint_map_contains (aprop->unsatroots,
                                          btor_aig_get_id (root)));
     }
-    else if ((!BTOR_IS_INVERTED_AIG (root)
-              && aigprop_get_assignment_aig (aprop, BTOR_REAL_ADDR_AIG (root))
+    else if ((!btor_aig_is_inverted (root)
+              && aigprop_get_assignment_aig (aprop, btor_aig_real_addr (root))
                      == 1)
-             || (BTOR_IS_INVERTED_AIG (root)
+             || (btor_aig_is_inverted (root)
                  && aigprop_get_assignment_aig (aprop,
-                                                BTOR_REAL_ADDR_AIG (root))
+                                                btor_aig_real_addr (root))
                         == -1))
     {
       assert (!btor_hashint_map_contains (aprop->unsatroots,
@@ -549,7 +549,7 @@ update_cone (AIGProp *aprop, BtorAIG *aig, int32_t assignment)
   while (!BTOR_EMPTY_STACK (stack))
   {
     cur = BTOR_POP_STACK (stack);
-    assert (BTOR_IS_REGULAR_AIG (cur));
+    assert (btor_aig_is_regular (cur));
     if (btor_hashint_table_contains (cache, cur->id)) continue;
     btor_hashint_table_add (cache, cur->id);
     if (cur != aig) BTOR_PUSH_STACK (cone, cur);
@@ -597,7 +597,7 @@ update_cone (AIGProp *aprop, BtorAIG *aig, int32_t assignment)
   for (i = 0; i < BTOR_COUNT_STACK (cone); i++)
   {
     cur = BTOR_PEEK_STACK (cone, i);
-    assert (BTOR_IS_REGULAR_AIG (cur));
+    assert (btor_aig_is_regular (cur));
     assert (btor_aig_is_and (cur));
     assert (btor_hashint_map_contains (aprop->model, cur->id));
 
@@ -629,7 +629,7 @@ update_cone (AIGProp *aprop, BtorAIG *aig, int32_t assignment)
     for (i = 0; i < BTOR_COUNT_STACK (cone); i++)
     {
       cur = BTOR_PEEK_STACK (cone, i);
-      assert (BTOR_IS_REGULAR_AIG (cur));
+      assert (btor_aig_is_regular (cur));
       assert (btor_aig_is_and (cur));
       assert (btor_hashint_map_contains (aprop->score, cur->id));
       assert (btor_hashint_map_contains (aprop->score, -cur->id));
@@ -673,21 +673,21 @@ update_cone (AIGProp *aprop, BtorAIG *aig, int32_t assignment)
   while (btor_iter_hashint_has_next (&it))
   {
     root = btor_aig_get_by_id (aprop->amgr, btor_iter_hashint_next (&it));
-    if ((!BTOR_IS_INVERTED_AIG (root)
-         && aigprop_get_assignment_aig (aprop, BTOR_REAL_ADDR_AIG (root)) == -1)
-        || (BTOR_IS_INVERTED_AIG (root)
-            && aigprop_get_assignment_aig (aprop, BTOR_REAL_ADDR_AIG (root))
+    if ((!btor_aig_is_inverted (root)
+         && aigprop_get_assignment_aig (aprop, btor_aig_real_addr (root)) == -1)
+        || (btor_aig_is_inverted (root)
+            && aigprop_get_assignment_aig (aprop, btor_aig_real_addr (root))
                    == 1))
     {
       assert (btor_hashint_map_contains (aprop->unsatroots,
                                          btor_aig_get_id (root)));
     }
-    else if ((!BTOR_IS_INVERTED_AIG (root)
-              && aigprop_get_assignment_aig (aprop, BTOR_REAL_ADDR_AIG (root))
+    else if ((!btor_aig_is_inverted (root)
+              && aigprop_get_assignment_aig (aprop, btor_aig_real_addr (root))
                      == 1)
-             || (BTOR_IS_INVERTED_AIG (root)
+             || (btor_aig_is_inverted (root)
                  && aigprop_get_assignment_aig (aprop,
-                                                BTOR_REAL_ADDR_AIG (root))
+                                                btor_aig_real_addr (root))
                         == -1))
     {
       assert (!btor_hashint_map_contains (aprop->unsatroots,
@@ -772,8 +772,8 @@ select_root (AIGProp *aprop, uint32_t nmoves)
   AIGPROPLOG (1, "");
   AIGPROPLOG (1,
               "*** select root: %s%d",
-              BTOR_IS_INVERTED_AIG (res) ? "-" : "",
-              BTOR_REAL_ADDR_AIG (res)->id);
+              btor_aig_is_inverted (res) ? "-" : "",
+              btor_aig_real_addr (res)->id);
   return res;
 }
 
@@ -800,18 +800,18 @@ select_move (AIGProp *aprop,
   cur    = root;
   asscur = 1;
 
-  if (btor_aig_is_var (BTOR_REAL_ADDR_AIG (cur)))
+  if (btor_aig_is_var (btor_aig_real_addr (cur)))
   {
-    *input      = BTOR_REAL_ADDR_AIG (cur);
-    *assignment = BTOR_IS_INVERTED_AIG (cur) ? -asscur : asscur;
+    *input      = btor_aig_real_addr (cur);
+    *assignment = btor_aig_is_inverted (cur) ? -asscur : asscur;
   }
   else
   {
     for (;;)
     {
-      real_cur = BTOR_REAL_ADDR_AIG (cur);
+      real_cur = btor_aig_real_addr (cur);
       assert (btor_aig_is_and (real_cur));
-      asscur = BTOR_IS_INVERTED_AIG (cur) ? -asscur : asscur;
+      asscur = btor_aig_is_inverted (cur) ? -asscur : asscur;
       c[0]   = btor_aig_get_by_id (aprop->amgr, real_cur->children[0]);
       c[1]   = btor_aig_get_by_id (aprop->amgr, real_cur->children[1]);
 
@@ -832,11 +832,11 @@ select_move (AIGProp *aprop,
         for (i = 0; i < 2; i++)
         {
           assert (btor_hashint_map_get (aprop->model,
-                                        BTOR_REAL_ADDR_AIG (c[i])->id));
+                                        btor_aig_real_addr (c[i])->id));
           d = btor_hashint_map_get (aprop->model,
-                                    BTOR_REAL_ADDR_AIG (c[i])->id);
+                                    btor_aig_real_addr (c[i])->id);
           assert (d);
-          ass[i] = BTOR_IS_INVERTED_AIG (c[i]) ? -d->as_int : d->as_int;
+          ass[i] = btor_aig_is_inverted (c[i]) ? -d->as_int : d->as_int;
         }
         if (ass[0] == -1 && ass[1] == 1)
           eidx = 0;
@@ -858,10 +858,10 @@ select_move (AIGProp *aprop,
       cur    = c[eidx];
       asscur = assnew;
 
-      if (btor_aig_is_var (BTOR_REAL_ADDR_AIG (cur)))
+      if (btor_aig_is_var (btor_aig_real_addr (cur)))
       {
-        *input      = BTOR_REAL_ADDR_AIG (cur);
-        *assignment = BTOR_IS_INVERTED_AIG (cur) ? -asscur : asscur;
+        *input      = btor_aig_real_addr (cur);
+        *assignment = btor_aig_is_inverted (cur) ? -asscur : asscur;
         break;
       }
     }
@@ -890,8 +890,8 @@ move (AIGProp *aprop, uint32_t nmoves)
   int32_t a = aigprop_get_assignment_aig (aprop, input);
   AIGPROPLOG (1,
               "    * input: %s%d",
-              BTOR_IS_INVERTED_AIG (input) ? "-" : "",
-              BTOR_REAL_ADDR_AIG (input)->id);
+              btor_aig_is_inverted (input) ? "-" : "",
+              btor_aig_real_addr (input)->id);
   AIGPROPLOG (1, "      prev. assignment: %d", a);
   AIGPROPLOG (1, "      new   assignment: %d", assignment);
 #endif
@@ -944,7 +944,7 @@ aigprop_sat (AIGProp *aprop, BtorIntHashTable *roots)
 
   while (!BTOR_EMPTY_STACK (stack))
   {
-    cur = BTOR_REAL_ADDR_AIG (BTOR_POP_STACK (stack));
+    cur = btor_aig_real_addr (BTOR_POP_STACK (stack));
     assert (!btor_aig_is_const (cur));
 
     if ((d = btor_hashint_map_get (cache, cur->id)) && d->as_int == 1) continue;

--- a/src/boolector.h
+++ b/src/boolector.h
@@ -2500,6 +2500,34 @@ const char *boolector_version (Btor *btor);
 const char *boolector_git_id (Btor *btor);
 
 /*------------------------------------------------------------------------*/
+/* AIG manager                                                            */
+/*------------------------------------------------------------------------*/
+
+typedef struct BoolectorAIGMgr BoolectorAIGMgr;
+
+typedef void (*BoolectorAIGVisitor) (
+    void *, bool, uint64_t, const char *, uint64_t, uint64_t);
+
+BoolectorAIGMgr *boolector_aig_new (Btor *btor);
+
+void boolector_aig_bitblast (BoolectorAIGMgr *mgr, BoolectorNode *node);
+
+void boolector_aig_visit (BoolectorAIGMgr *mgr,
+                          BoolectorNode *node,
+                          BoolectorAIGVisitor func,
+                          void *state);
+
+uint64_t *boolector_aig_get_bits (BoolectorAIGMgr *mgr, BoolectorNode *node);
+
+const char *boolector_aig_get_symbol (BoolectorAIGMgr *mgr, uint64_t aig);
+
+void boolector_aig_free_bits (BoolectorAIGMgr *mgr,
+                              uint64_t *bits,
+                              size_t nbits);
+
+void boolector_aig_delete (BoolectorAIGMgr *mgr);
+
+/*------------------------------------------------------------------------*/
 #if __cplusplus
 }
 #endif

--- a/src/btoraig.h
+++ b/src/btoraig.h
@@ -78,13 +78,29 @@ typedef struct BtorAIGMgr BtorAIGMgr;
 
 #define BTOR_AIG_TRUE ((BtorAIG *) 1ul)
 
-#define BTOR_INVERT_AIG(aig) ((BtorAIG *) (1ul ^ (uintptr_t) (aig)))
+static inline BtorAIG *
+btor_aig_invert (const BtorAIG *aig)
+{
+  return (BtorAIG *) (1ul ^ (uintptr_t) (aig));
+}
 
-#define BTOR_IS_INVERTED_AIG(aig) (1ul & (uintptr_t) (aig))
+static inline bool
+btor_aig_is_inverted (const BtorAIG *aig)
+{
+  return (1ul & (uintptr_t) (aig));
+}
 
-#define BTOR_REAL_ADDR_AIG(aig) ((BtorAIG *) (~1ul & (uintptr_t) (aig)))
+static inline BtorAIG *
+btor_aig_real_addr (const BtorAIG *aig)
+{
+  return (BtorAIG *) (~1ul & (uintptr_t) (aig));
+}
 
-#define BTOR_IS_REGULAR_AIG(aig) (!(1ul & (uintptr_t) (aig)))
+static inline bool
+btor_aig_is_regular (const BtorAIG *aig)
+{
+  return !(1ul & (uintptr_t) (aig));
+}
 
 /*------------------------------------------------------------------------*/
 
@@ -125,7 +141,7 @@ btor_aig_get_id (const BtorAIG *aig)
 {
   assert (aig);
   assert (!btor_aig_is_const (aig));
-  return BTOR_IS_INVERTED_AIG (aig) ? -BTOR_REAL_ADDR_AIG (aig)->id : aig->id;
+  return btor_aig_is_inverted (aig) ? -btor_aig_real_addr (aig)->id : aig->id;
 }
 
 static inline BtorAIG *
@@ -133,7 +149,7 @@ btor_aig_get_by_id (BtorAIGMgr *amgr, int32_t id)
 {
   assert (amgr);
 
-  return id < 0 ? BTOR_INVERT_AIG (BTOR_PEEK_STACK (amgr->id2aig, -id))
+  return id < 0 ? btor_aig_invert (BTOR_PEEK_STACK (amgr->id2aig, -id))
                 : BTOR_PEEK_STACK (amgr->id2aig, id);
 }
 
@@ -142,7 +158,7 @@ btor_aig_get_cnf_id (const BtorAIG *aig)
 {
   if (btor_aig_is_true (aig)) return 1;
   if (btor_aig_is_false (aig)) return -1;
-  return BTOR_IS_INVERTED_AIG (aig) ? -BTOR_REAL_ADDR_AIG (aig)->cnf_id
+  return btor_aig_is_inverted (aig) ? -btor_aig_real_addr (aig)->cnf_id
                                     : aig->cnf_id;
 }
 
@@ -152,7 +168,7 @@ btor_aig_get_left_child (BtorAIGMgr *amgr, const BtorAIG *aig)
   assert (amgr);
   assert (aig);
   assert (!btor_aig_is_const (aig));
-  return btor_aig_get_by_id (amgr, BTOR_REAL_ADDR_AIG (aig)->children[0]);
+  return btor_aig_get_by_id (amgr, btor_aig_real_addr (aig)->children[0]);
 }
 
 static inline BtorAIG *
@@ -161,7 +177,7 @@ btor_aig_get_right_child (BtorAIGMgr *amgr, const BtorAIG *aig)
   assert (amgr);
   assert (aig);
   assert (!btor_aig_is_const (aig));
-  return btor_aig_get_by_id (amgr, BTOR_REAL_ADDR_AIG (aig)->children[1]);
+  return btor_aig_get_by_id (amgr, btor_aig_real_addr (aig)->children[1]);
 }
 
 /*------------------------------------------------------------------------*/

--- a/src/btoraigvec.c
+++ b/src/btoraigvec.c
@@ -769,3 +769,94 @@ btor_aigvec_get_aig_mgr (const BtorAIGVecMgr *avmgr)
 {
   return avmgr ? avmgr->amgr : 0;
 }
+
+static uint64_t
+aiger_lit (int64_t lit)
+{
+  if (lit == 0 || lit == 1) return lit;
+  return lit < 0 ? (-lit << 1) + 1 : lit << 1;
+}
+
+void
+btor_aigvec_visit_aigs (BtorAIGVecMgr *avmgr,
+                        BtorAIGVec *av,
+                        BtorIntHashTable *symbols,
+                        BtorAIGVecVisitor func,
+                        void *state)
+{
+  uint32_t i;
+  int32_t id, id_c0, id_c1;
+  BtorMemMgr *mm;
+  BtorAIGPtrStack visit;
+  BtorIntHashTable *cache;
+  BtorAIG *aig, *real_aig;
+  BtorAIGMgr *amgr;
+  BtorHashTableData *d;
+  const char *sym;
+
+  mm   = avmgr->btor->mm;
+  amgr = avmgr->amgr;
+
+  cache = btor_hashint_map_new (mm);
+  BTOR_INIT_STACK (mm, visit);
+
+  for (i = 0; i < av->width; i++)
+  {
+    BTOR_PUSH_STACK (visit, av->aigs[i]);
+    do
+    {
+      aig      = BTOR_POP_STACK (visit);
+      real_aig = btor_aig_real_addr (aig);
+      id_c0 = id_c1 = 0;
+
+      if (aig == BTOR_AIG_TRUE || aig == BTOR_AIG_FALSE)
+      {
+        id = (size_t) aig;
+      }
+      else
+      {
+        id = real_aig->id;
+        if (!real_aig->is_var)
+        {
+          id_c0 = real_aig->children[0];
+          id_c1 = real_aig->children[1];
+        }
+      }
+
+      d   = btor_hashint_map_get (symbols, id);
+      sym = d ? d->as_str : 0;
+
+      if (!(d = btor_hashint_map_get (cache, id)))
+      {
+        BTOR_PUSH_STACK (visit, aig);
+        d = btor_hashint_map_add (cache, id);
+        d->flag = false;
+        func (state,
+              false,
+              aiger_lit (id),
+              sym,
+              aiger_lit (id_c0),
+              aiger_lit (id_c1));
+        if (aig != BTOR_AIG_TRUE && aig != BTOR_AIG_FALSE && !real_aig->is_var)
+        {
+          assert (id_c0);
+          assert (id_c1);
+          BTOR_PUSH_STACK (visit, btor_aig_get_by_id (amgr, id_c0));
+          BTOR_PUSH_STACK (visit, btor_aig_get_by_id (amgr, id_c1));
+        }
+      }
+      else if (!d->flag)
+      {
+        func (state,
+              true,
+              aiger_lit (id),
+              sym,
+              aiger_lit (id_c0),
+              aiger_lit (id_c1));
+        d->flag = true;
+      }
+    } while (!BTOR_EMPTY_STACK (visit));
+  }
+  btor_hashint_map_delete (cache);
+  BTOR_RELEASE_STACK (visit);
+}

--- a/src/btoraigvec.c
+++ b/src/btoraigvec.c
@@ -80,7 +80,7 @@ btor_aigvec_invert (BtorAIGVecMgr *avmgr, BtorAIGVec *av)
   assert (av);
   assert (av->width > 0);
   width = av->width;
-  for (i = 0; i < width; i++) av->aigs[i] = BTOR_INVERT_AIG (av->aigs[i]);
+  for (i = 0; i < width; i++) av->aigs[i] = btor_aig_invert (av->aigs[i]);
 }
 
 BtorAIGVec *
@@ -148,14 +148,14 @@ lt_aigvec (BtorAIGVecMgr *avmgr, BtorAIGVec *av1, BtorAIGVec *av2)
   res  = BTOR_AIG_FALSE;
   for (j = 1, i = av1->width - 1; j <= av1->width; j++, i--)
   {
-    term0 = btor_aig_and (amgr, av1->aigs[i], BTOR_INVERT_AIG (av2->aigs[i]));
+    term0 = btor_aig_and (amgr, av1->aigs[i], btor_aig_invert (av2->aigs[i]));
 
-    tmp = btor_aig_and (amgr, BTOR_INVERT_AIG (term0), res);
+    tmp = btor_aig_and (amgr, btor_aig_invert (term0), res);
     btor_aig_release (amgr, term0);
     btor_aig_release (amgr, res);
     res = tmp;
 
-    term1 = btor_aig_and (amgr, BTOR_INVERT_AIG (av1->aigs[i]), av2->aigs[i]);
+    term1 = btor_aig_and (amgr, btor_aig_invert (av1->aigs[i]), av2->aigs[i]);
 
     tmp = btor_aig_or (amgr, term1, res);
     btor_aig_release (amgr, term1);
@@ -213,11 +213,11 @@ half_adder (BtorAIGMgr *amgr, BtorAIG *x, BtorAIG *y, BtorAIG **cout)
 {
   BtorAIG *res, *x_and_y, *not_x, *not_y, *not_x_and_not_y, *x_xnor_y;
   x_and_y         = btor_aig_and (amgr, x, y);
-  not_x           = BTOR_INVERT_AIG (x);
-  not_y           = BTOR_INVERT_AIG (y);
+  not_x           = btor_aig_invert (x);
+  not_y           = btor_aig_invert (y);
   not_x_and_not_y = btor_aig_and (amgr, not_x, not_y);
   x_xnor_y        = btor_aig_or (amgr, x_and_y, not_x_and_not_y);
-  res             = BTOR_INVERT_AIG (x_xnor_y);
+  res             = btor_aig_invert (x_xnor_y);
   *cout           = x_and_y;
   btor_aig_release (amgr, not_x_and_not_y);
   return res;
@@ -474,11 +474,11 @@ SC_GATE_S_aigvec (BtorAIGMgr *amgr,
   BtorAIG *T1, *T2;
   D_or_CI  = btor_aig_or (amgr, D, CI);
   D_and_CI = btor_aig_and (amgr, D, CI);
-  T1       = btor_aig_and (amgr, D_or_CI, BTOR_INVERT_AIG (D_and_CI));
+  T1       = btor_aig_and (amgr, D_or_CI, btor_aig_invert (D_and_CI));
   T2       = btor_aig_and (amgr, T1, Q);
   T2_or_R  = btor_aig_or (amgr, T2, R);
   T2_and_R = btor_aig_and (amgr, T2, R);
-  *S       = btor_aig_and (amgr, T2_or_R, BTOR_INVERT_AIG (T2_and_R));
+  *S       = btor_aig_and (amgr, T2_or_R, btor_aig_invert (T2_and_R));
   btor_aig_release (amgr, T1);
   btor_aig_release (amgr, T2);
   btor_aig_release (amgr, D_and_CI);
@@ -510,7 +510,7 @@ udiv_urem_aigvec (BtorAIGVecMgr *avmgr,
   for (i = 0; i < size; i++) A[i] = Ain->aigs[size - 1 - i];
 
   BTOR_NEWN (mem, nD, size);
-  for (i = 0; i < size; i++) nD[i] = BTOR_INVERT_AIG (Din->aigs[size - 1 - i]);
+  for (i = 0; i < size; i++) nD[i] = btor_aig_invert (Din->aigs[size - 1 - i]);
 
   BTOR_NEWN (mem, S, size + 1);
   for (j = 0; j <= size; j++)
@@ -682,14 +682,14 @@ btor_aigvec_clone (BtorAIGVec *av, BtorAIGVecMgr *avmgr)
     else
     {
       aig = av->aigs[i];
-      assert (BTOR_REAL_ADDR_AIG (aig)->id >= 0);
-      assert ((size_t) BTOR_REAL_ADDR_AIG (aig)->id
+      assert (btor_aig_real_addr (aig)->id >= 0);
+      assert ((size_t) btor_aig_real_addr (aig)->id
               < BTOR_COUNT_STACK (amgr->id2aig));
-      caig = BTOR_PEEK_STACK (amgr->id2aig, BTOR_REAL_ADDR_AIG (aig)->id);
+      caig = BTOR_PEEK_STACK (amgr->id2aig, btor_aig_real_addr (aig)->id);
       assert (caig);
       assert (!btor_aig_is_const (caig));
-      if (BTOR_IS_INVERTED_AIG (aig))
-        res->aigs[i] = BTOR_INVERT_AIG (caig);
+      if (btor_aig_is_inverted (aig))
+        res->aigs[i] = btor_aig_invert (caig);
       else
         res->aigs[i] = caig;
       assert (res->aigs[i]);

--- a/src/btoraigvec.h
+++ b/src/btoraigvec.h
@@ -16,6 +16,7 @@
 #include "btorbv.h"
 #include "btoropt.h"
 #include "btortypes.h"
+#include "utils/btorhashint.h"
 #include "utils/btormem.h"
 
 struct BtorAIGMap;
@@ -184,4 +185,17 @@ void btor_aigvec_to_sat_tseitin (BtorAIGVecMgr *avmgr, BtorAIGVec *av);
 
 /* Release all AIGs of the AIG vector and delete AIG vector from memory. */
 void btor_aigvec_release_delete (BtorAIGVecMgr *avmgr, BtorAIGVec *av);
+
+/* TODO:
+ * A visitor takes the state (void *), a flag indicating if post traversal,
+ * and 3 AIG node ids (node id, child0 id, child1 id). Note: child0 and child1
+ * will be 0 if node is an AIG variable. */
+typedef void (*BtorAIGVecVisitor) (
+    void *, bool, uint64_t, const char *, uint64_t, uint64_t);
+
+void btor_aigvec_visit_aigs (BtorAIGVecMgr *avmgr,
+                             BtorAIGVec *av,
+                             BtorIntHashTable *symbols,
+                             BtorAIGVecVisitor func,
+                             void *state);
 #endif

--- a/src/btorbitblast.c
+++ b/src/btorbitblast.c
@@ -1,0 +1,192 @@
+/*  Boolector: Satisfiability Modulo Theories (SMT) solver.
+ *
+ *  Copyright (C) 2019 Mathias Preiner.
+ *
+ *  This file is part of Boolector.
+ *  See COPYING for more information on using this software.
+ */
+
+#include "btorbitblast.h"
+
+#include "btorabort.h"
+#include "btorcore.h"
+#include "btornode.h"
+#include "utils/btorhashint.h"
+#include "utils/btorutil.h"
+
+BtorAIGVec *
+btor_bitblast_exp (Btor *btor,
+                   BtorAIGVecMgr *avmgr,
+                   BtorNode *exp,
+                   BtorPtrHashTable *node_to_aigvec,
+                   BtorIntHashTable *symbols)
+{
+  assert (btor);
+  assert (exp);
+
+  size_t len;
+  uint32_t i, bw;
+  BtorMemMgr *mm;
+  BtorNode *cur;
+  BtorNodePtrStack visit;
+  BtorIntHashTable *cache;
+  BtorHashTableData *d, *dd;
+  BtorPtrHashBucket *b;
+  BtorAIGVec *res, *av[3] = {0, 0, 0};
+  const char *name;
+  char *buf;
+
+  mm    = btor->mm;
+  cache = btor_hashint_map_new (btor->mm);
+
+  BTOR_INIT_STACK (btor->mm, visit);
+  BTOR_PUSH_STACK (visit, exp);
+
+  while (!BTOR_EMPTY_STACK (visit))
+  {
+    cur = btor_node_real_addr (BTOR_POP_STACK (visit));
+
+    if (!(d = btor_hashint_map_get (cache, cur->id)))
+    {
+      d = btor_hashint_map_add (cache, cur->id);
+
+      if (node_to_aigvec && (b = btor_hashptr_table_get (node_to_aigvec, cur)))
+      {
+        d->as_ptr = btor_aigvec_copy (avmgr, b->data.as_ptr);
+        continue;
+      }
+
+      BTOR_PUSH_STACK (visit, cur);
+      for (i = 0; i < cur->arity; i++)
+      {
+        BTOR_PUSH_STACK (visit, cur->e[i]);
+      }
+    }
+    else if (!d->as_ptr)
+    {
+      for (i = 0; i < cur->arity; i++)
+      {
+        dd = btor_hashint_map_get (cache, btor_node_real_addr (cur->e[i])->id);
+        assert (dd->as_ptr);
+        if (btor_node_is_inverted (cur->e[i]))
+        {
+          av[i] = btor_aigvec_not (avmgr, dd->as_ptr);
+        }
+        else
+        {
+          av[i] = btor_aigvec_copy (avmgr, dd->as_ptr);
+        }
+      }
+
+      res = 0;
+      switch (cur->kind)
+      {
+        case BTOR_CONST_NODE:
+          res = btor_aigvec_const (avmgr, btor_node_bv_const_get_bits (cur));
+          break;
+        case BTOR_VAR_NODE:
+          bw  = btor_node_bv_get_width (btor, cur);
+          res = btor_aigvec_var (avmgr, bw);
+
+          if (btor_node_is_bv_var (cur) && symbols
+              && (name = btor_node_get_symbol (btor, cur)))
+          {
+            len = strlen (name) + 3 + btor_util_num_digits (bw);
+            if (btor_node_bv_get_width (btor, cur) > 1)
+            {
+              buf = btor_mem_malloc (btor->mm, len);
+              for (i = 0; i < res->width; i++)
+              {
+                snprintf (buf, len, "%s[%u]", name, res->width - i - 1);
+                btor_hashint_map_add (symbols, res->aigs[i]->id << 1)->as_str =
+                    btor_mem_strdup (mm, buf);
+              }
+              btor_mem_free (mm, buf, len);
+            }
+            else
+            {
+              assert (btor_node_bv_get_width (btor, cur) == 1);
+              btor_hashint_map_add (symbols, res->aigs[0]->id << 1)->as_str =
+                  btor_mem_strdup (btor->mm, name);
+            }
+          }
+          break;
+        case BTOR_BV_SLICE_NODE:
+          res = btor_aigvec_slice (avmgr,
+                                   av[0],
+                                   btor_node_bv_slice_get_upper (cur),
+                                   btor_node_bv_slice_get_lower (cur));
+          break;
+        case BTOR_BV_AND_NODE:
+          res = btor_aigvec_and (avmgr, av[0], av[1]);
+          break;
+        case BTOR_BV_EQ_NODE: res = btor_aigvec_eq (avmgr, av[0], av[1]); break;
+        case BTOR_BV_ADD_NODE:
+          res = btor_aigvec_add (avmgr, av[0], av[1]);
+          break;
+        case BTOR_BV_MUL_NODE:
+          res = btor_aigvec_mul (avmgr, av[0], av[1]);
+          break;
+        case BTOR_BV_ULT_NODE:
+          res = btor_aigvec_ult (avmgr, av[0], av[1]);
+          break;
+        case BTOR_BV_SLL_NODE:
+          res = btor_aigvec_sll (avmgr, av[0], av[1]);
+          break;
+        case BTOR_BV_SRL_NODE:
+          res = btor_aigvec_srl (avmgr, av[0], av[1]);
+          break;
+        case BTOR_BV_UDIV_NODE:
+          res = btor_aigvec_udiv (avmgr, av[0], av[1]);
+          break;
+        case BTOR_BV_UREM_NODE:
+          res = btor_aigvec_urem (avmgr, av[0], av[1]);
+          break;
+        case BTOR_BV_CONCAT_NODE:
+          res = btor_aigvec_concat (avmgr, av[0], av[1]);
+          break;
+        case BTOR_COND_NODE:
+          res = btor_aigvec_cond (avmgr, av[0], av[1], av[2]);
+          break;
+        default:
+          BTOR_ABORT (true,
+                      "Unsupported kind for bit-blasting: %s",
+                      g_btor_op2str[cur->kind]);
+      }
+      assert (res);
+      d->as_ptr = res;
+
+      if (node_to_aigvec)
+      {
+        btor_hashptr_table_add (node_to_aigvec, btor_node_copy (btor, cur))
+            ->data.as_ptr = btor_aigvec_copy (avmgr, res);
+      }
+
+      for (i = 0; i < cur->arity; i++)
+      {
+        btor_aigvec_release_delete (avmgr, av[i]);
+      }
+    }
+  }
+  BTOR_RELEASE_STACK (visit);
+
+  if (btor_node_is_inverted (exp))
+  {
+    d = btor_hashint_map_get (cache, cur->id);
+    assert (d->as_ptr);
+    res = btor_aigvec_not (avmgr, d->as_ptr);
+  }
+  else
+  {
+    res = btor_aigvec_copy (avmgr, d->as_ptr);
+  }
+
+  for (i = 0; i < cache->size; i++)
+  {
+    if (!cache->data[i].as_ptr) continue;
+    btor_aigvec_release_delete (avmgr, cache->data[i].as_ptr);
+  }
+  btor_hashint_map_delete (cache);
+
+  return res;
+}

--- a/src/btorbitblast.h
+++ b/src/btorbitblast.h
@@ -1,0 +1,23 @@
+/*  Boolector: Satisfiability Modulo Theories (SMT) solver.
+ *
+ *  Copyright (C) 2019 Mathias Preiner.
+ *
+ *  This file is part of Boolector.
+ *  See COPYING for more information on using this software.
+ */
+
+#ifndef BTORBITBLAST_H_INCLUDED
+#define BTORBITBLAST_H_INCLUDED
+
+#include "btoraigvec.h"
+#include "btortypes.h"
+#include "utils/btorhashint.h"
+#include "utils/btorhashptr.h"
+
+BtorAIGVec *btor_bitblast_exp (Btor *btor,
+                               BtorAIGVecMgr *avmgr,
+                               BtorNode *exp,
+                               BtorPtrHashTable *node_to_aigvec,
+                               BtorIntHashTable *symbols);
+
+#endif

--- a/src/btorchkclone.c
+++ b/src/btorchkclone.c
@@ -359,8 +359,8 @@ chkclone_opts (Btor *btor, Btor *clone)
       assert (!real_clone->field);                        \
       break;                                              \
     }                                                     \
-    assert (BTOR_IS_INVERTED_AIG (real_aig->field)        \
-            == BTOR_IS_INVERTED_AIG (real_clone->field)); \
+    assert (btor_aig_is_inverted (real_aig->field)        \
+            == btor_aig_is_inverted (real_clone->field)); \
     BTOR_CHKCLONE_AIGPID (field);                         \
   } while (0)
 
@@ -370,8 +370,8 @@ chkclone_aig (BtorAIG *aig, BtorAIG *clone)
   int32_t i;
   BtorAIG *real_aig, *real_clone;
 
-  real_aig   = BTOR_REAL_ADDR_AIG (aig);
-  real_clone = BTOR_REAL_ADDR_AIG (clone);
+  real_aig   = btor_aig_real_addr (aig);
+  real_clone = btor_aig_real_addr (clone);
   assert ((real_aig == BTOR_AIG_FALSE && real_clone == BTOR_AIG_FALSE)
           || real_aig != real_clone);
 

--- a/src/btorcore.c
+++ b/src/btorcore.c
@@ -1802,9 +1802,9 @@ exp_to_cnf_lit (Btor *btor, BtorNode *exp)
   }
   else
   {
-    if (BTOR_IS_INVERTED_AIG (aig))
+    if (btor_aig_is_inverted (aig))
     {
-      aig = BTOR_INVERT_AIG (aig);
+      aig = btor_aig_invert (aig);
       sign *= -1;
     }
 

--- a/src/btorslvaigprop.c
+++ b/src/btorslvaigprop.c
@@ -69,8 +69,8 @@ get_assignment_aig (AIGProp *aprop, BtorAIG *aig)
   if (aig == BTOR_AIG_TRUE) return 1;
   if (aig == BTOR_AIG_FALSE) return -1;
   /* initialize don't care bits with false */
-  if (!btor_hashint_map_contains (aprop->model, BTOR_REAL_ADDR_AIG (aig)->id))
-    return BTOR_IS_INVERTED_AIG (aig) ? 1 : -1;
+  if (!btor_hashint_map_contains (aprop->model, btor_aig_real_addr (aig)->id))
+    return btor_aig_is_inverted (aig) ? 1 : -1;
   return aigprop_get_assignment_aig (aprop, aig);
 }
 
@@ -255,7 +255,7 @@ sat_aigprop_solver (BtorAIGPropSolver *slv)
     if (!btor_node_real_addr (root)->av) btor_synthesize_exp (btor, root, 0);
     assert (btor_node_real_addr (root)->av->width == 1);
     aig = btor_node_real_addr (root)->av->aigs[0];
-    if (btor_node_is_inverted (root)) aig = BTOR_INVERT_AIG (aig);
+    if (btor_node_is_inverted (root)) aig = btor_aig_invert (aig);
     if (aig == BTOR_AIG_FALSE) goto UNSAT;
     if (aig == BTOR_AIG_TRUE) continue;
     if (!btor_hashint_table_contains (roots, btor_aig_get_id (aig)))

--- a/src/dumper/btordumpaig.c
+++ b/src/dumper/btordumpaig.c
@@ -26,14 +26,14 @@ aiger_encode_aig (BtorPtrHashTable *table, BtorAIG *aig)
 
   if (aig == BTOR_AIG_TRUE) return 1;
 
-  real_aig = BTOR_REAL_ADDR_AIG (aig);
+  real_aig = btor_aig_real_addr (aig);
 
   b = btor_hashptr_table_get (table, real_aig);
   assert (b);
 
   res = 2 * (uint32_t) b->data.as_int;
 
-  if (BTOR_IS_INVERTED_AIG (aig)) res ^= 1;
+  if (btor_aig_is_inverted (aig)) res ^= 1;
 
   return res;
 }
@@ -239,7 +239,7 @@ btor_dumpaig_dump_seq (BtorAIGMgr *amgr,
   CONTINUE_WITHOUT_POP:
 
     assert (!btor_aig_is_const (aig));
-    aig = BTOR_REAL_ADDR_AIG (aig);
+    aig = btor_aig_real_addr (aig);
 
     if (aig->mark) continue;
 
@@ -303,7 +303,7 @@ btor_dumpaig_dump_seq (BtorAIGMgr *amgr,
     CONTINUE_WITH_NON_ZERO_AIG:
 
       assert (!btor_aig_is_const (aig));
-      aig = BTOR_REAL_ADDR_AIG (aig);
+      aig = btor_aig_real_addr (aig);
 
       if (!aig->mark) continue;
 
@@ -329,7 +329,7 @@ btor_dumpaig_dump_seq (BtorAIGMgr *amgr,
       assert (!aig->mark);
 
       assert (aig);
-      assert (BTOR_REAL_ADDR_AIG (aig) == aig);
+      assert (btor_aig_real_addr (aig) == aig);
       assert (btor_aig_is_and (aig));
 
       p              = btor_hashptr_table_add (table, aig);
@@ -354,7 +354,7 @@ btor_dumpaig_dump_seq (BtorAIGMgr *amgr,
     aig = p->key;
 
     assert (aig);
-    assert (!BTOR_IS_INVERTED_AIG (aig));
+    assert (!btor_aig_is_inverted (aig));
 
     if (!btor_aig_is_var (aig)) break;
 
@@ -386,7 +386,7 @@ btor_dumpaig_dump_seq (BtorAIGMgr *amgr,
     aig = p->key;
 
     assert (aig);
-    assert (!BTOR_IS_INVERTED_AIG (aig));
+    assert (!btor_aig_is_inverted (aig));
     assert (btor_aig_is_and (aig));
 
     left  = btor_aig_get_left_child (amgr, aig);

--- a/src/utils/btoraigmap.c
+++ b/src/utils/btoraigmap.c
@@ -40,12 +40,12 @@ btor_aigmap_mapped (BtorAIGMap *map, BtorAIG *aig)
   BtorPtrHashBucket *bucket;
   BtorAIG *real_aig, *res;
 
-  real_aig = BTOR_REAL_ADDR_AIG (aig);
+  real_aig = btor_aig_real_addr (aig);
   bucket   = btor_hashptr_table_get (map->table, real_aig);
   if (!bucket) return 0;
   assert (bucket->key == real_aig);
   res = bucket->data.as_ptr;
-  if (BTOR_IS_INVERTED_AIG (aig)) res = BTOR_INVERT_AIG (res);
+  if (btor_aig_is_inverted (aig)) res = btor_aig_invert (res);
   return res;
 }
 
@@ -58,11 +58,11 @@ btor_aigmap_map (BtorAIGMap *map, BtorAIG *src, BtorAIG *dst)
 
   BtorPtrHashBucket *bucket;
 
-  if (BTOR_IS_INVERTED_AIG (src))
+  if (btor_aig_is_inverted (src))
   {
-    assert (BTOR_IS_INVERTED_AIG (dst));
-    src = BTOR_INVERT_AIG (src);
-    dst = BTOR_INVERT_AIG (dst);
+    assert (btor_aig_is_inverted (dst));
+    src = btor_aig_invert (src);
+    dst = btor_aig_invert (dst);
   }
   assert (!btor_hashptr_table_get (map->table, src));
   bucket = btor_hashptr_table_add (map->table, src);

--- a/src/utils/btorhashint.c
+++ b/src/utils/btorhashint.c
@@ -252,8 +252,6 @@ btor_hashint_table_size (BtorIntHashTable *t)
 size_t
 btor_hashint_table_add (BtorIntHashTable *t, int32_t key)
 {
-  assert (key);
-
   size_t pos;
 
   //  print_density (t, key);

--- a/test/testaigvec.c
+++ b/test/testaigvec.c
@@ -72,15 +72,15 @@ test_invert_aigvec (void)
   assert (width == 32);
   for (i = 0; i < width; i++)
   {
-    assert (!BTOR_IS_INVERTED_AIG (av1->aigs[i]));
+    assert (!btor_aig_is_inverted (av1->aigs[i]));
     assert (btor_aig_is_var (av1->aigs[i]));
   }
   btor_aigvec_invert (avmgr, av1);
-  for (i = 0; i < width; i++) assert (BTOR_IS_INVERTED_AIG (av1->aigs[i]));
+  for (i = 0; i < width; i++) assert (btor_aig_is_inverted (av1->aigs[i]));
   btor_aigvec_invert (avmgr, av1);
   for (i = 0; i < width; i++)
   {
-    assert (!BTOR_IS_INVERTED_AIG (av1->aigs[i]));
+    assert (!btor_aig_is_inverted (av1->aigs[i]));
     assert (btor_aig_is_var (av1->aigs[i]));
   }
   assert (av2->aigs[0] == BTOR_AIG_TRUE);


### PR DESCRIPTION
The scripts  `contrib/setup-btor2tools.sh` and  `contrib/setup-utils.sh` on the `bitblast-api` branch are updated to the latest version as on master commit 74c9e8822d1d4e5f8c9e0df68e02309d1505e280.

This fixes an issue (https://github.com/Boolector/btor2tools/issues/5) with compiling `btor2tools` with AIGER support, which pulls in the `bitblast-api` branch.