### PR TITLE
Add copyright acknowledgement when linking against CryptoMiniSat

### DIFF
--- a/src/boolector.c
+++ b/src/boolector.c
@@ -4914,7 +4914,7 @@ boolector_copyright (Btor *btor)
   return "This software is\n"
          "Copyright (c) 2007-2009 Robert Brummayer\n"
          "Copyright (c) 2007-2018 Armin Biere\n"
-         "Copyright (c) 2012-2019 Aina Niemetz, Mathias Preiner\n"
+         "Copyright (c) 2012-2020 Aina Niemetz, Mathias Preiner\n"
 #ifdef BTOR_USE_LINGELING
          "\n"
          "This software is linked against Lingeling\n"
@@ -4933,12 +4933,12 @@ boolector_copyright (Btor *btor)
 #ifdef BTOR_USE_CADICAL
          "\n"
          "This software is linked against CaDiCaL\n"
-         "Copyright (c) 2016-2019 Armin Biere\n"
+         "Copyright (c) 2016-2020 Armin Biere\n"
 #endif
 #ifdef BTOR_USE_CMS
          "\n"
          "This software is linked against CryptoMiniSat\n"
-         "Copyright (c) 2009-2018 Mate Soos\n"
+         "Copyright (c) 2009-2020 Mate Soos\n"
 #endif
          "";
 }

--- a/src/boolector.c
+++ b/src/boolector.c
@@ -4935,6 +4935,11 @@ boolector_copyright (Btor *btor)
          "This software is linked against CaDiCaL\n"
          "Copyright (c) 2016-2019 Armin Biere\n"
 #endif
+#ifdef BTOR_USE_CMS
+         "\n"
+         "This software is linked against CryptoMiniSat\n"
+         "Copyright (c) 2009-2018 Mate Soos\n"
+#endif
          "";
 }
 


### PR DESCRIPTION
I noticed that if you compile Boolector with CMS, then CMS *is not* listed in `--copyright`.

This PR corrects that.

The years were taken from `deps/cryptominisat/debian/cryptominisat5.copyright` (there are no 2019s/2020s in the `deps/cryptominisat` folder).

Signed-off-by: Andrew V. Jones <andrew.jones@vector.com>