### PR TITLE
When printing a value in 'smt2' format, ensure that Bools are presented correctly

### DIFF
--- a/src/btorprintmodel.c
+++ b/src/btorprintmodel.c
@@ -444,6 +444,7 @@ print_bv_value_smt2 (
 
   char *symbol;
   const BtorBitVector *ass;
+  BtorPtrHashBucket *b;
   int32_t id;
 
   ass    = btor_model_get_bv (btor, node);
@@ -458,7 +459,15 @@ print_bv_value_smt2 (
         file, "(v%d ", id ? id : btor_node_get_id (btor_node_real_addr (node)));
   }
 
-  btor_dumpsmt_dump_const_value (btor, ass, base, file);
+  b = btor_hashptr_table_get (btor->inputs, node);
+  if (b && b->data.flag)
+  {
+    fprintf (file, "%s", btor_bv_is_true (ass) ? "true" : "false");
+  }
+  else
+  {
+    btor_dumpsmt_dump_const_value (btor, ass, base, file);
+  }
   fprintf (file, ")");
 }
 


### PR DESCRIPTION
Quick attempt to fix #136

It seems that this was "half done" in https://github.com/Boolector/boolector/commit/55febfd8d61b14acb19538254886435377fc0d59, so I've just tried to make sure the logic is consistent for the example in #136.

I'm not sure why the aforementioned commit formats things like:

```
((b Bool false))
```

though (this branch **does not** do that).

Signed-off-by: Andrew V. Jones <andrew.jones@vector.com>