### PR TITLE
When installing, also install btoropt.h #140

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -140,7 +140,7 @@ install(EXPORT boolector-export
   DESTINATION lib/cmake/Boolector)
 
 # Install header files
-install(FILES boolector.h btortypes.h DESTINATION include/boolector)
+install(FILES boolector.h btortypes.h btoropt.h DESTINATION include/boolector)
 
 #-----------------------------------------------------------------------------#
 # boolector


### PR DESCRIPTION
## Issue

Boolector's install target does not install `btoropt.h`, which is required to set options via the API

## Resolution

This PR ensure that header is installed.

Signed-off-by: Andrew V. Jones <andrew.jones@vector.com>