### PR TITLE
SAT/UNSAT return code when dumping a formula simplified to true/false

### DIFF
--- a/src/btormain.c
+++ b/src/btormain.c
@@ -1503,7 +1503,9 @@ boolector_main (int32_t argc, char **argv)
   /* we don't dump formula(s) in incremental mode */
   else if (dump)
   {
-    (void) boolector_simplify (btor);
+    // if the formula is simplified to true or false we don't actually dump anything,
+    // so let the caller know about it by the return code
+    sat_res = boolector_simplify (btor);
 
     switch (dump)
     {


### PR DESCRIPTION
Usecase:
when using boolector in AIGER dump mode, if the formula is proved unsat, boolector seems to not output anything instead of outputing an unsat AIGER formula. It's apparenlty impossible to distinguish "formula was sat" and "formula was unsat" in the current state of things.
Solution:
This PR makes use of the boolector exit codes to convey this information.

Tests pass when this patch is applied on top of 3.2.1 (one test does not pass on current master, and it still does not pass with this patch applied obviously).