### PR TITLE
contrib/setup-utils.sh: Recognize 64-bit MinGW

### DIFF
--- a/contrib/setup-utils.sh
+++ b/contrib/setup-utils.sh
@@ -66,7 +66,7 @@ function is_windows
   # otherwise.
   #
   case "$(uname -s)" in
-    CYGWIN*|MINGW32*|MSYS*)
+    CYGWIN*|MINGW32*|MINGW64*|MSYS*)
       return
       ;;
   esac


### PR DESCRIPTION
On 64-bit versions of MinGW, `uname -s` will output:

```
$ uname -s
MINGW64_NT-10.0-19044
```

This trips up the `is_windows` function in `contrib/setup-utils.sh`, however, as it only checks for `MINGW32*`, not `MINGW64*`. As a result, trying to build `boolector` with 64-bit MinGW will fail since the proper Windows-specific patches are not applied.

This provides a simple fix of checking both `MINGW32*` and `MINGW64*`.