### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,8 +78,22 @@ cd boolector
 # Download and build BTOR2Tools
 ./contrib/setup-btor2tools.sh
 
+# Configure Boolector
+./configure.sh
+
+chmod -R o+rw .
+
 # Build Boolector
-./configure.sh && cd build && make
+cd build/
+make
+
+# Global Installation
+sudo make install
+
+try:=>($locate boolector.h)(should show you the path)
+
+# Globalization of header files
+setenv CPATH "/usr/local/include/boolector/:$PATH"
 ```
 
 All binaries (boolector, btormc, btormbt, btoruntrace) are generated into
@@ -122,6 +136,7 @@ include directories, libraries and it's dependencies.
 After installing Boolector you can issue the following commands in your CMake
 project to link against Boolector.
 ```
+(in CMakeList.txt file)
 find_package(Boolector)
 target_link_libraries(<your_target> Boolector::boolector)
 ```


### PR DESCRIPTION
When making a global installation with 'sudo make install', it showed an error of user mismatch while creating intall_manifest.txt. As in command it's root but folder in under different user. 'chmod -R o+rw .' will help a lot of users with installation. "setenv CPATH "/usr/local/include/boolector/:$PATH"" will help to globalize all related header files.

Signed-off-by: Gourish Singla <singlagourish0@gmail.com>