### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,8 +78,21 @@ cd boolector
 # Download and build BTOR2Tools
 ./contrib/setup-btor2tools.sh
 
-# Build Boolector
-./configure.sh && cd build && make
+# Configure Boolector
+./configure.sh 
+
+chmod -R o+rw .
+
+#Build Boolector 
+cd build/
+make
+
+#Global Installation
+sudo make install
+try:=>($locate boolector.h)(should show you the path)
+
+#For globalisation of all header files
+setenv CPATH "/usr/local/include/boolector/:$PATH"
 ```
 
 All binaries (boolector, btormc, btormbt, btoruntrace) are generated into


### PR DESCRIPTION
When making a global installation with `sudo make install`, it showed an error of user mismatch while creating intall_manifest.txt. As in command it's root but folder in under different user. `chmod -R o+rw .` will help a lot of users with installation. `setenv CPATH "/usr/local/include/boolector/:$PATH"` will help to globalize all related header files.

Signed-off-by: Gourish Singla 63445410+gsingla21@users.noreply.github.com