### PR TITLE
Python: Only use repaired wheels as artifacts

### DIFF
--- a/pypi/azure-pipelines-pypi.yml
+++ b/pypi/azure-pipelines-pypi.yml
@@ -99,6 +99,8 @@ jobs:
   - script: |
       sudo pip3 install twine
       python3 -m twine --version
+      echo "Files to upload:"
+      ls -l $(Agent.BuildDirectory)/dist-*/*.whl $(Agent.BuildDirectory)/dist-*/*.tar.gz
       echo "Calling twine"
       python3 -m twine upload -r pyboolector --config-file $(PYPIRC_PATH) $(Agent.BuildDirectory)/dist-*/*.whl $(Agent.BuildDirectory)/dist-*/*.tar.gz
       echo "Calling twine complete"

--- a/pypi/build.sh
+++ b/pypi/build.sh
@@ -46,6 +46,10 @@ export CMAKELISTS_TXT=/boolector/CMakeLists.txt
 
 cp -r /boolector/pypi pyboolector
 
+# Prepare the artifact directory.
+rm -rf /boolector/result
+mkdir -p /boolector/result
+
 # Grab the main license file
 cp /boolector/COPYING pyboolector/LICENSE
 
@@ -69,12 +73,10 @@ for py in $PYTHON_VERSIONS; do
   $python setup.py sdist bdist_wheel
 done
 
+# Copy the source distribution into the artifact directory.
+cp dist/*.tar.gz /boolector/result
+
+# Repair wheels and place them into the artifact directory.
 for whl in dist/*.whl; do
-  auditwheel repair $whl
+  auditwheel repair --wheel-dir /boolector/result/dist $whl
 done
-
-rm -rf /boolector/result
-mkdir -p /boolector/result
-
-cp -r dist /boolector/result
-cp -r wheelhouse/* /boolector/result/dist


### PR DESCRIPTION
The Python bdist (wheel) build process produces wheels named e.g.
`PyBoolector-3.2.2.20220630.7-cp39-cp39-linux_ppc64le.whl`. These
wheels are then "repaired" (libraries are bundled) by auditwheel
to produce files like
`PyBoolector-3.2.2.20220630.7-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl`.

In our previous build process, we had the original linux_ and the repaired
manylinux_ wheels in the same directory, and hence tried to upload both
to PyPi. This upload failed with an error message from PyPi:

```
ERROR    HTTPError: 400 Bad Request from https://upload.pypi.org/legacy/
         Binary wheel
         'PyBoolector-3.2.2.20220701.1-cp310-cp310-linux_ppc64le.whl' has an
         unsupported platform tag 'linux_ppc64le'.
```

Fix the problem by only placing the repaired wheels into the Azure
Pipelines build artifacts, and hence only uploading those files.