### PR TITLE
Fix for missing MAP_ANONYMOUS

### DIFF
--- a/src/btormbt.c
+++ b/src/btormbt.c
@@ -171,6 +171,10 @@ void boolector_print_value_smt2 (Btor *, BoolectorNode *, char *, FILE *);
 #define FORCE_SHADOW_TRUE 1
 #define FORCE_SHADOW_FALSE -1
 
+#ifndef MAP_ANONYMOUS
+#define MAP_ANONYMOUS MAP_ANON
+#endif
+
 /*------------------------------------------------------------------------*/
 
 #define BTORMBT_STR(str) #str


### PR DESCRIPTION
On macOS prior to 10.11 there is no define of `MAP_ANONYMOUS`. Instead, `MAP_ANON` is to be used.
See: https://github.com/macports/macports-legacy-support/blob/44df1150df2f20421b067a37f73410981d8b5a5a/include/sys/mman.h#L27

P. S. Apparently the same fix also applies to Sparc, though I cannot verify that personally: https://github.com/xianyi/OpenBLAS/blob/5d6fde58e3abababebce33a30160527854acd9b7/common_sparc.h#L239