### PR TITLE
Add ifdef guards for successful compile to wasm.

### DIFF
--- a/src/boolector.c
+++ b/src/boolector.c
@@ -293,8 +293,10 @@ boolector_delete (Btor *btor)
   BTOR_TRAPI ("");
   if (btor->close_apitrace == 1)
     fclose (btor->apitrace);
+#ifndef __wasm
   else if (btor->close_apitrace == 2)
     pclose (btor->apitrace);
+#endif
 #ifndef NDEBUG
   if (btor->clone) boolector_delete (btor->clone);
 #endif

--- a/src/btormain.c
+++ b/src/btormain.c
@@ -21,7 +21,9 @@
 
 #include <assert.h>
 #include <limits.h>
+#ifndef __wasm
 #include <signal.h>
+#endif
 #include <stdarg.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -1061,7 +1063,9 @@ boolector_main (int32_t argc, char **argv)
       else if (btor_util_file_has_suffix (g_app->infile_name, ".zip"))
         sprintf (cmd, "unzip -p %s", g_app->infile_name);
 
+#ifndef __wasm
       if ((g_app->infile = popen (cmd, "r"))) g_app->close_infile = 2;
+#endif
 
       BTOR_DELETEN (g_app->mm, cmd, len + 40);
     }
@@ -1595,8 +1599,10 @@ DONE:
 
   if (g_app->close_infile == 1)
     fclose (g_app->infile);
+#ifndef __wasm
   else if (g_app->close_infile == 2)
     pclose (g_app->infile);
+#endif
   if (g_app->close_outfile) fclose (g_app->outfile);
 
   if (!boolector_get_opt (btor, BTOR_OPT_EXIT_CODES))

--- a/src/btormcmain.c
+++ b/src/btormcmain.c
@@ -818,7 +818,9 @@ main (int32_t argc, char **argv)
       else if (btor_util_file_has_suffix (infile_name, ".zip"))
         sprintf (cmd, "unzip -p %s", infile_name);
 
+#ifndef __wasm
       if ((infile = popen (cmd, "r"))) close_infile = 2;
+#endif
 
       BTOR_DELETEN (mm, cmd, len + 40);
     }
@@ -956,8 +958,10 @@ main (int32_t argc, char **argv)
 DONE:
   if (close_infile == 1)
     fclose (infile);
+#ifndef __wasm
   else if (close_infile == 2)
     pclose (infile);
+#endif
   boolector_mc_delete (mc);
   while (!BTOR_EMPTY_STACK (opts))
   {

--- a/src/btortrapi.c
+++ b/src/btortrapi.c
@@ -64,7 +64,9 @@ btor_trapi_open_trace (Btor *btor, const char *name)
     len += 20;
     BTOR_NEWN (btor->mm, cmd, len);
     sprintf (cmd, "gzip -c > %s", name);
+#ifndef __wasm
     if ((file = popen (cmd, "w"))) btor->close_apitrace = 2;
+#endif
     BTOR_DELETEN (btor->mm, cmd, len);
   }
   else


### PR DESCRIPTION
I [recently](https://github.com/cr1901/yowasp-boolector/actions/runs/7536963674/job/20515181787) got `boolector` to successfully compile for [WebAssembly](https://webassembly.org/).

I am using [local patches](https://github.com/cr1901/yowasp-boolector/blob/main/boolector.patch) for the time being, but this PR introduces my patches to upstream. This should be merged after the equivalent [`btor2tools` PR](https://github.com/Boolector/btor2tools/pull/18).